### PR TITLE
Assign a new valid port if port is in use

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -49,18 +49,30 @@ function startServer(bundleStats, opts) {
     });
   });
 
-  return app.listen(opts.port, () => {
-    const url = `http://localhost:${opts.port}`;
+  function listen(port) {
+    const server = app.listen(port, () => {
+      const url = `http://localhost:${port}`;
 
-    console.log(
-      `${bold('Webpack Bundle Analyzer')} is started at ${bold(url)}\n` +
-      `Use ${bold('Ctrl+C')} to close it`
-    );
+      console.log(
+          `${bold('Webpack Bundle Analyzer')} is started at ${bold(url)}\n` +
+          `Use ${bold('Ctrl+C')} to close it`
+      );
 
-    if (opts.openBrowser) {
-      opener(url);
-    }
-  });
+      if (opts.openBrowser) {
+        opener(url);
+      }
+    });
+
+    server.once('error', (err) => {
+      const nextPort = port + 1;
+      console.warn(`Unable to listen on port ${port}`);
+      console.warn(`Error code: ${bold(err.code)}`);
+      console.log(`Trying port ${nextPort}`);
+      listen(nextPort);
+    });
+  }
+
+  listen(opts.port);
 }
 
 function generateReport(bundleStats, opts) {


### PR DESCRIPTION
It was requested in #12 and I am also using a similar setup, as the one described there, so I thought I'd adjust `viewer.js` to retry to `.listen()` to a new port if the currently assigned one is already in use.

# Possible improvements:

Since now it retries by simply using the next port, if you have, say `k` instances of the plugin (all using port 8888 for example), for any nth instance it will invoke `app.listen()` `n` times, until it gets one port that's unused. Maybe we could be storing already used ports and assigning a new one by checking them first, so that we just do one `app.listen()` call, which will be guaranteed to succeed. Then again maybe that's an overkill anyway.

P.S. I am not sure which branch I was supposed to use as base. 