### PR TITLE
Display reasons why module was included

### DIFF
--- a/client/components/ModuleButton.css
+++ b/client/components/ModuleButton.css
@@ -1,0 +1,38 @@
+.button {
+  display: block;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: inherit;
+  max-width: 100%;
+  float: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: initial;
+  line-height: 1.25em;
+  cursor: pointer;
+}
+
+.button:after {
+  content: ".";
+  display: block;
+  float: left;
+  width: 4em;
+  margin: -1em -2em;
+  color: #fff;
+  background: #fff;
+  background: linear-gradient(to right, rgba(255,255,255,1) 50%,rgba(255,255,255,0) 100%);
+}
+
+.content {
+  float: right;
+  min-width: 100%;
+  margin-top: 0;
+  margin-left: -1px;
+}
+
+
+
+.button:hover {
+  text-decoration: underline;
+}

--- a/client/components/ModuleButton.jsx
+++ b/client/components/ModuleButton.jsx
@@ -1,0 +1,16 @@
+/** @jsx h */
+import { h } from 'preact';
+import s from './ModuleButton.css';
+
+const ModuleButton = ( { module, onClick } ) => (
+  <button className={s.button} type="button" onClick={onClick}>
+    <div className={s.content}>
+      {module.path.replace('./node_modules/', '~')
+        .replace(/\/index\.(js|jsx)$/, '')
+      }
+      {module.reasons.length > 0 && ` (${module.reasons.length})`}
+    </div>
+  </button>
+);
+
+export default ModuleButton;

--- a/client/components/ModuleInfo.css
+++ b/client/components/ModuleInfo.css
@@ -1,0 +1,17 @@
+.wrapper {
+  font-size: 11px;
+  font-family: Verdana;
+}
+
+.path {
+  overflow-wrap: break-word;
+}
+
+.reasons {
+  margin-top: 10px;
+  font-weight: bold;
+}
+
+.list {
+  margin-top: 10px;
+}

--- a/client/components/ModuleInfo.jsx
+++ b/client/components/ModuleInfo.jsx
@@ -1,0 +1,43 @@
+/** @jsx h */
+/* eslint-disable react/no-multi-comp */
+import { h } from 'preact';
+import cls from 'classnames';
+import ModuleList from './ModuleList';
+import s from './ModuleInfo.css';
+import filesize from 'filesize';
+
+import { SIZE_SWITCH_ITEMS } from '../constants';
+
+const ModuleSize = ({ module, sizeType } ) => {
+  const sizeProp = `${sizeType}Size`;
+  const size = module[sizeProp];
+  const sizeLabel = SIZE_SWITCH_ITEMS.find(item => item.prop === sizeProp).label;
+
+  return (typeof size === 'number') ?
+    <div>
+      {sizeLabel} size: <strong>{filesize(size)}</strong>
+    </div>
+    :
+    null;
+};
+
+const ModuleInfo = ({ module, className, onModuleClick } ) => (
+  <div className={cls(className, s.wrapper)}>
+    <div><strong>{module.label}</strong></div>
+    <br/>
+    <ModuleSize module={module} sizeType="stat"/>
+    <ModuleSize module={module} sizeType="parsed"/>
+    <ModuleSize module={module} sizeType="gzip"/>
+    {module.path &&
+      <span className={s.path}>Path: <strong>{module.path}</strong></span>
+    }
+    {module.reasons &&
+      [
+        <div key="reasons-header" className={s.reasons}>Reasons:</div>,
+        <ModuleList key="reasons-list" className={s.list} modules={module.reasons} onModuleClick={onModuleClick}/>
+      ]
+    }
+  </div>
+);
+
+export default ModuleInfo;

--- a/client/components/ModuleList.css
+++ b/client/components/ModuleList.css
@@ -1,0 +1,10 @@
+.list {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.listItem {
+  display: flex;
+  padding: 0;
+}

--- a/client/components/ModuleList.jsx
+++ b/client/components/ModuleList.jsx
@@ -1,0 +1,19 @@
+/** @jsx h */
+import { h } from 'preact';
+import cls from 'classnames';
+import ModuleButton from './ModuleButton';
+import s from './ModuleList.css';
+
+const ModuleList = ( { modules, onModuleClick, className } ) => (
+  <ul className={cls(s.list, className)}>
+    {modules.map(module => (
+      <li key={module.id} className={s.listItem}>
+        {
+          // eslint-disable-next-line react/jsx-no-bind
+        }<ModuleButton module={module} onClick={onModuleClick.bind(null, module)}/>
+      </li>
+    ))}
+  </ul>
+);
+
+export default ModuleList;

--- a/client/components/ModuleSearch.css
+++ b/client/components/ModuleSearch.css
@@ -1,0 +1,13 @@
+.wrapper {
+  font-family: Verdana;
+  font-size: 11px;
+}
+
+.input {
+  padding: 2px;
+  width: 100%;
+}
+
+.list {
+  padding: 10px 0;
+}

--- a/client/components/ModuleSearch.jsx
+++ b/client/components/ModuleSearch.jsx
@@ -1,0 +1,42 @@
+/** @jsx h */
+import { h, Component } from 'preact';
+import ModuleList from './ModuleList';
+import s from './ModuleSearch.css';
+
+export default class ModuleSearch extends Component {
+
+  constructor( props ) {
+    super(props);
+  }
+
+  componentDidMount( ) {
+    this.input.focus();
+  }
+
+  render( ) {
+
+    const { query } = this.props;
+    let modules = [];
+
+    if (query) {
+      modules = this.props.modules.filter(module => (
+        module.path.indexOf(query) !== -1
+      ));
+    }
+
+    return (
+      <div className={s.wrapper}>
+        <input ref={this.onRef}
+          value={query}
+          className={s.input}
+          onInput={this.props.onChange}/>
+        <ModuleList className={s.list} modules={modules} onModuleClick={this.props.onModuleClick}/>
+      </div>
+    );
+  }
+
+  onRef = ref => {
+    this.input = ref;
+  }
+
+}

--- a/client/components/ModulesTreemap.css
+++ b/client/components/ModulesTreemap.css
@@ -1,13 +1,25 @@
 .container, .map {
-  position: relative;
+  position: absolute;
+  top: 0;
   width: 100%;
   height: 100%;
 }
 
 .sidebarGroup {
   margin-bottom: 20px;
+  clear: both;
 }
 
 .activeSize {
   font-weight: bold;
+}
+
+.moduleInfo {
+  padding-bottom: 10px;
+  border-bottom: 1px solid lightgrey;
+  margin-bottom: 10px;
+}
+
+.backButton {
+  margin-bottom: 10px;
 }

--- a/client/components/Sidebar.css
+++ b/client/components/Sidebar.css
@@ -2,14 +2,16 @@
   background: #fff;
   border: none;
   border-right: 1px solid #aaa;
-  bottom: 0;
   opacity: 0.95;
   overflow-y: auto;
-  padding: 20px;
-  position: absolute;
-  top: 0;
+  padding: 10px;
+  position: relative;
+  height: 100vh;
   transition: transform .2s ease;
   z-index: 1;
+  display: inline-block;
+  padding-right: 50px;
+  max-width: 350px;
 }
 
 .container.left {
@@ -18,4 +20,10 @@
 
 .container.left.hidden {
   transform: translateX(calc(-100% + 7px));
+}
+
+.closeButton {
+  position: absolute;
+  top: 10px;
+  right: 10px;
 }

--- a/client/components/Sidebar.jsx
+++ b/client/components/Sidebar.jsx
@@ -24,7 +24,7 @@ export default class Sidebar extends Component {
 
   render() {
     const { position, children } = this.props;
-    const { visible } = this.state;
+    const visible = this.state.visible || this.props.locked;
 
     const className = cls({
       [s.container]: true,
@@ -36,7 +36,12 @@ export default class Sidebar extends Component {
       <div className={className}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}>
-        {children}
+        <button className={s.closeButton} onClick={this.handleCloseClick}>
+          ✕
+        </button>
+        <div>
+          {children}
+        </div>
       </div>
     );
   }
@@ -47,6 +52,11 @@ export default class Sidebar extends Component {
   };
 
   handleMouseLeave = () => this.toggleVisibility(false);
+
+  handleCloseClick = ( event ) => {
+    this.toggleVisibility(false);
+    this.props.onCloseClick(event);
+  }
 
   toggleVisibility(flag) {
     this.setState({ visible: flag });

--- a/client/components/Tooltip.css
+++ b/client/components/Tooltip.css
@@ -5,7 +5,7 @@
   border-radius: 4px;
   background: #fff;
   border: 1px solid #aaa;
-  opacity: 0.7;
+  opacity: 0.85;
   white-space: nowrap;
   visibility: visible;
   transition: opacity .2s ease, visibility .2s ease;

--- a/client/components/Treemap.jsx
+++ b/client/components/Treemap.jsx
@@ -71,8 +71,14 @@ export default class Treemap extends Component {
       },
       onGroupClick(event) {
         preventDefault(event);
-        zoomOutDisabled = false;
-        this.zoom(event.group);
+        if (event.ctrlKey || event.metaKey) {
+          if (props.onGroupClick) {
+            props.onGroupClick(event);
+          }
+        } else {
+          zoomOutDisabled = false;
+          this.zoom(event.group);
+        }
       },
       onGroupDoubleClick: preventDefault,
       onGroupHover(event) {

--- a/client/constants.js
+++ b/client/constants.js
@@ -1,0 +1,5 @@
+export const SIZE_SWITCH_ITEMS = [
+  { label: 'Stat', prop: 'statSize' },
+  { label: 'Parsed', prop: 'parsedSize' },
+  { label: 'Gzipped', prop: 'gzipSize' }
+];

--- a/src/tree.js
+++ b/src/tree.js
@@ -65,6 +65,12 @@ class Module extends Node {
     return this._gzipSize;
   }
 
+  get reasons( ) {
+    return this.data.reasons ?
+      this.data.reasons.map(reason => _.pick(reason, 'moduleName', 'moduleId'))
+      : this.data.reasons;
+  }
+
   mergeData(data) {
     if (data.size) {
       this.size += data.size;
@@ -86,7 +92,8 @@ class Module extends Node {
       path: this.path,
       statSize: this.size,
       parsedSize: this.parsedSize,
-      gzipSize: this.gzipSize
+      gzipSize: this.gzipSize,
+      reasons: this.reasons
     };
   }
 


### PR DESCRIPTION
First of all, thanks for a wonderful tool! It has been super helpful in our attempts to reduce the bundle size of our main application.

One of the things that was slightly difficult for me though is figuring out why stuff was in the bundle. I started using the `reasons` metadata in `stats.json` to trace back the origins, but it's quite cumbersome to grep a JSON file. I thought it would be helpful to have this in the UI as well.

Here's what the change does:

**Search for modules**. 
The user is a presented with an input field in the sidebar, which will allow them to filter a list of modules in the bundle. 

**Display the reasons a module was included**
For every module, the reasons why it was included in the displayed in the module info block. The weird CSS you see in ModuleButton is used to fake a text-overflow from the start rather than the end, because the latter part of the module's path is more identifying than the first few folders.

**Adds the concept of selected modules**. 
This allows the user to select or pin a module, and have its info displayed in the sidebar. There are three ways to select a module:
- Single-clicking a module in the treemap _(note: this changes current behaviour, where a single click triggers zooming in on that module - that is now possible by a double click)_.
- Entering a search query in the input field, and clicking one of the modules that are listed.
- Clicking on a reason of the currently displayed module.

Once a module is selected, `window.location.hash` is updated with the id of the module. If the user has selected a module group rather than a module, the name of the module is prefilled in the input field to allow the user to search for modules in that group.

The user can deselect a module by clicking on the close button of the sidebar, or they can use a back button that is displayed to go the previously selected module or query. They can also just use browser navigation to quickly navigate back and forth between selected modules. This allows the user to quickly do drill-downs of reasons why modules were included.

![image](https://im2.ezgif.com/tmp/ezgif-2-0ad2c1cd8f.gif)

