### PR TITLE
Output large json stats objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "acorn": "^5.1.1",
+    "bfj": "^4.2.4",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "ejs": "^2.5.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "acorn": "^5.1.1",
-    "bfj": "^4.2.4",
+    "bfj-node4": "^4.2.4",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "ejs": "^2.5.6",

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -61,29 +61,27 @@ class BundleAnalyzerPlugin {
     });
   }
 
-  generateStatsFile(stats) {
+  async generateStatsFile(stats) {
     const statsFilepath = path.resolve(this.compiler.outputPath, this.opts.statsFilename);
     mkdir.sync(path.dirname(statsFilepath));
 
-    const options = {
-      promises: 'ignore',
-      buffers: 'ignore',
-      maps: 'ignore',
-      iterables: 'ignore',
-      circular: 'ignore'
-    };
-    return bfj.write(statsFilepath, stats, options)
-      .then(() => {
-        this.logger.info(
-          `${bold('Webpack Bundle Analyzer')} saved stats file to ${bold(statsFilepath)}`
-        );
-      })
-      .catch((error) => {
-        this.logger.error(
-          `${bold('Webpack Bundle Analyzer')} error saving stats file to ${bold(statsFilepath)}.`,
-          JSON.stringify(error, null, '\t')
-        );
+    try {
+      await bfj.write(statsFilepath, stats, {
+        promises: 'ignore',
+        buffers: 'ignore',
+        maps: 'ignore',
+        iterables: 'ignore',
+        circular: 'ignore'
       });
+
+      this.logger.info(
+        `${bold('Webpack Bundle Analyzer')} saved stats file to ${bold(statsFilepath)}`
+      );
+    } catch (error) {
+      this.logger.error(
+        `${bold('Webpack Bundle Analyzer')} error saving stats file to ${bold(statsFilepath)}: ${error}`
+      );
+    }
   }
 
   async startAnalyzerServer(stats) {

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -1,4 +1,4 @@
-const bfj = require('bfj');
+const bfj = require('bfj-node4');
 const path = require('path');
 const mkdir = require('mkdirp');
 const { bold } = require('chalk');

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -81,7 +81,7 @@ class BundleAnalyzerPlugin {
       .catch((error) => {
         this.logger.error(
           `${bold('Webpack Bundle Analyzer')} error saving stats file to ${bold(statsFilepath)}.`,
-          JSON.stringify(error, null, "\n") // eslint-disable-line quotes
+          JSON.stringify(error, null, '\t')
         );
       });
   }

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const bfj = require('bfj');
 const path = require('path');
 const mkdir = require('mkdirp');
 const { bold } = require('chalk');
@@ -63,17 +63,27 @@ class BundleAnalyzerPlugin {
 
   generateStatsFile(stats) {
     const statsFilepath = path.resolve(this.compiler.outputPath, this.opts.statsFilename);
-
     mkdir.sync(path.dirname(statsFilepath));
 
-    fs.writeFileSync(
-      statsFilepath,
-      JSON.stringify(stats, null, 2)
-    );
-
-    this.logger.info(
-      `${bold('Webpack Bundle Analyzer')} saved stats file to ${bold(statsFilepath)}`
-    );
+    const options = {
+      promises: 'ignore',
+      buffers: 'ignore',
+      maps: 'ignore',
+      iterables: 'ignore',
+      circular: 'ignore'
+    };
+    return bfj.write(statsFilepath, stats, options)
+      .then(() => {
+        this.logger.info(
+          `${bold('Webpack Bundle Analyzer')} saved stats file to ${bold(statsFilepath)}`
+        );
+      })
+      .catch((error) => {
+        this.logger.error(
+          `${bold('Webpack Bundle Analyzer')} error saving stats file to ${bold(statsFilepath)}.`,
+          JSON.stringify(error, null, "\n") // eslint-disable-line quotes
+        );
+      });
   }
 
   async startAnalyzerServer(stats) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,6 +755,14 @@ beeper@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
 
+bfj@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/bfj/-/bfj-4.2.4.tgz#85f7b23683c2afdc15860384a2d1c3fac80ed33a"
+  dependencies:
+    check-types "^7.3.0"
+    hoopy "^0.1.2"
+    tryer "^1.0.0"
+
 big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
@@ -962,6 +970,10 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+check-types@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-7.3.0.tgz#468f571a4435c24248f5fd0cb0e8d87c3c341e7d"
 
 chokidar@^1.4.3, chokidar@^1.6.0, chokidar@^1.6.1:
   version "1.7.0"
@@ -2457,6 +2469,10 @@ homedir-polyfill@^1.0.0:
   resolved "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
     parse-passwd "^1.0.0"
+
+hoopy@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.2.tgz#bd64d4648eb13d77971a129a493fbb380b030602"
 
 hosted-git-info@^2.1.4:
   version "2.4.2"
@@ -4881,6 +4897,10 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+tryer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.0.tgz#027b69fa823225e551cace3ef03b11f6ab37c1d7"
 
 tryit@^1.0.1:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,12 +755,11 @@ beeper@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
 
-bfj@^4.2.4:
+bfj-node4@^4.2.4:
   version "4.2.4"
-  resolved "https://registry.yarnpkg.com/bfj/-/bfj-4.2.4.tgz#85f7b23683c2afdc15860384a2d1c3fac80ed33a"
+  resolved "https://registry.yarnpkg.com/bfj-node4/-/bfj-node4-4.2.4.tgz#8484fe2ec73ea195906f3fd26ebd309be233e91a"
   dependencies:
     check-types "^7.3.0"
-    hoopy "^0.1.2"
     tryer "^1.0.0"
 
 big.js@^3.1.3:
@@ -2469,10 +2468,6 @@ homedir-polyfill@^1.0.0:
   resolved "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
     parse-passwd "^1.0.0"
-
-hoopy@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.2.tgz#bd64d4648eb13d77971a129a493fbb380b030602"
 
 hosted-git-info@^2.1.4:
   version "2.4.2"


### PR DESCRIPTION
Fixes #119 

I've seen this problem appear in the logs as:
```
fs.writeFileSync(statsFilepath, JSON.stringify(stats, null, 2));
RangeError: Invalid string length
```

The problem is that we're trying to serialize the whole stats object into JSON at once, which causes memory issues with larger projects. The stats object has a shape including `{"assets": [...], "entrypoints": {...}, "chunks": [...], "modules": [...]}` and it's the `chunks` and `modules` fields that are really large lists.

~~To fix this I imported JSONStream and paired it with a writable stream to serialize and flush each key on it's own. For larger projects we might need to go further and iterate/write each item within the chunks/modules/children keys individually.~~
