### PR TITLE
Add a listener for the 'error' event on the WebSocket server client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 branches:
   only:
     - master
@@ -10,21 +11,12 @@ cache:
   - yarn: true
   - directories:
     - node_modules
-env:
-  # Required to compile native modules for Node.js v4+
-  # See https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
-  - CXX=g++-4.8
 addons:
   apt:
-    sources:
-      # Required to compile native modules for Node.js v4+
-      - ubuntu-toolchain-r-test
     packages:
       # Required by Electron
       # https://github.com/juliangruber/electron-stream#travis
       - xvfb
-      # Required to compile native modules for Node.js v4+
-      - g++-4.8
 before_script:
   # Required by Electron
   - export DISPLAY=':99.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## UNRELEASED
+
+ * **Bug Fix**
+   * Add a listener for the 'error' event on the WebSocket server client (#140)
+
+ * **Internal**
+   * Clean up .travis.yml (#140)
+   * Update ws to version 4.0.0 (#140)
+
 ## 2.9.1
 
  * **Bug Fix**
@@ -18,7 +27,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 ## 2.9.0
  * **New Feature**
    * Show chunk sizes in sidebar (closes #91)
-   
+
  * **Bug Fix**
    * Properly parse webpack bundles that use arrow functions as module wrappers (#108, @regiontog)
 
@@ -31,7 +40,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 ## 2.8.2
  * **Improvement**
    * Greatly improved accuracy of gzip sizes
- 
+
  * **Bug Fix**
    * Generate report file in the bundle output directory when used with Webpack Dev Server (fixes #75)
 
@@ -43,7 +52,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
  * **Improvement**
    * Analyzer now supports `webpack --watch` and Webpack Dev Server!
      It will automatically update modules treemap according to changes in the sources via WebSockets!
- 
+
  * **Internal**
    * Use `babel-preset-env` and two different Babel configs to compile node and browser code
    * Update deps
@@ -67,7 +76,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 ## 2.4.0
  * **Bug Fix**
    * Fix `TypeError: currentFolder.addModule is not a function`
-  
+
  * **Internal**
    * Update deps
 
@@ -78,7 +87,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 ## 2.3.0
  * **Improvement**
    * Add `analyzerHost` option (@freaz)
-  
+
  * **Internal**
    * Update deps
 
@@ -136,37 +145,37 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
    * Workaround `Express` bug that caused wrong `ejs` version to be used as view engine (fixes #17)
 
 ## 1.5.2
- 
+
  * **Bug Fix**
    * Support array module descriptors that can be generated if `DedupePlugin` is used (fixes #4)
 
 ## 1.5.1
- 
+
  * **Internal**
    * Plug analyzer to Webpack compiler `done` event instead of `emit`. Should fix #15.
 
 ## 1.5.0
- 
+
  * **New Feature**
    * Add `statsOptions` option for `BundleAnalyzerPlugin`
 
 ## 1.4.2
- 
+
  * **Bug Fix**
    * Fix "Unable to find bundle asset" error when bundle name starts with `/` (fixes #3)
 
 ## 1.4.1
- 
+
  * **Bug Fix**
    * Add partial support for `DedupePlugin` (see #4 for more info)
 
 ## 1.4.0
- 
+
  * **New Feature**
    * Add "static report" mode (closes #2)
 
 ## 1.3.0
- 
+
  * **Improvement**
    * Add `startAnalyzer` option for `BundleAnalyzerPlugin` (fixes #1)
  * **Internal**

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "opener": "^1.4.3",
-    "ws": "^3.3.1"
+    "ws": "^4.0.0"
   },
   "devDependencies": {
     "babel-core": "6.24.1",

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -74,6 +74,15 @@ async function startServer(bundleStats, opts) {
 
   const wss = new WebSocket.Server({ server });
 
+  wss.on('connection', ws => {
+    ws.on('error', err => {
+      // Ignore network errors like `ECONNRESET`, `EPIPE`, etc.
+      if (err.errno) return;
+
+      logger.info(err.message);
+    });
+  });
+
   return {
     ws: wss,
     http: server,

--- a/test/viewer.js
+++ b/test/viewer.js
@@ -1,0 +1,66 @@
+const crypto = require('crypto');
+const net = require('net');
+
+const Logger = require('../lib/Logger');
+const { startServer } = require('../lib/viewer.js');
+
+describe('WebSocket server', function () {
+  it('should not crash when an error is emitted on the websocket', function (done) {
+    const bundleStats = {
+      assets: [{ name: 'bundle.js', chunks: [0] }]
+    };
+
+    const options = {
+      openBrowser: false,
+      logger: new Logger('silent'),
+      port: 0
+    };
+
+    startServer(bundleStats, options).then(function ({ http: server }) {
+      // The GUID constant defined in WebSocket protocol
+      // https://tools.ietf.org/html/rfc6455#section-1.3
+      const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+      // The client-generated "Sec-WebSocket-Key" header field value.
+      const key = crypto.randomBytes(16).toString('base64');
+
+      // The server-generated "Sec-WebSocket-Accept" header field value.
+      const accept = crypto.createHash('sha1')
+        .update(key + GUID)
+        .digest('base64');
+
+      const socket = net.createConnection(server.address().port, function () {
+        socket.write([
+          'GET / HTTP/1.1',
+          'Host: localhost',
+          'Upgrade: websocket',
+          'Connection: Upgrade',
+          `Sec-WebSocket-Key: ${key}`,
+          'Sec-WebSocket-Version: 13',
+          '',
+          ''
+        ].join('\r\n'));
+      });
+
+      socket.on('data', function (chunk) {
+        const expected = Buffer.from([
+          'HTTP/1.1 101 Switching Protocols',
+          'Upgrade: websocket',
+          'Connection: Upgrade',
+          `Sec-WebSocket-Accept: ${accept}`,
+          '',
+          ''
+        ].join('\r\n'));
+
+        expect(chunk.equals(expected)).to.be.true;
+
+        // Send a WebSocket frame with a reserved opcode (5) to trigger an error
+        // to be emitted on the server.
+        socket.write(Buffer.from([0x85, 0x00]));
+        socket.on('close', function () {
+          server.close(done);
+        });
+      });
+    }).catch(done);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4955,8 +4955,8 @@ uid-number@^0.0.6:
   resolved "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
 ultron@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
 
 unc-path-regex@^0.1.0:
   version "0.1.2"
@@ -5260,9 +5260,9 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.1.tgz#d97e34dee06a1190c61ac1e95f43cb60b78cf939"
+ws@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-4.0.0.tgz#bfe1da4c08eeb9780b986e0e4d10eccd7345999f"
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"


### PR DESCRIPTION
This prevents the process from exiting when an `'error'` event is emitted on the WebSocket server client.

Refs: https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/138
  