### PR TITLE
Simplify gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,12 +17,15 @@ if (task === 'build' || cli.analyze) {
 }
 
 gulp.task('clean', gulp.parallel(cleanNodeScripts, cleanViewerScripts));
-gulp.task('build', gulp.series('clean', compileNodeScripts(), compileViewerScripts));
+gulp.task('build', gulp.series('clean', compileNodeScripts, compileViewerScripts));
 gulp.task('watch', gulp.series('build', watch));
 gulp.task('default', gulp.task('watch'));
 
 function watch() {
-  gulp.watch(NODE_SRC, gulp.series(cleanNodeScripts, compileNodeScripts(true)));
+  gulp
+    .watch(NODE_SRC, gulp.series(cleanNodeScripts, compileNodeScripts))
+    // TODO: replace with `emitErrors: false` option after https://github.com/gulpjs/glob-watcher/pull/34 will be merged
+    .on('error', () => {});
 }
 
 function cleanViewerScripts() {
@@ -35,18 +38,13 @@ function cleanNodeScripts() {
   return del(NODE_DEST);
 }
 
-function compileNodeScripts(justLogErrors) {
-  return function compileNodeScripts() {
-    const babel = require('gulp-babel');
-    const plumber = require('gulp-plumber');
-    const noop = require('gulp-noop');
+function compileNodeScripts() {
+  const babel = require('gulp-babel');
 
-    return gulp
-      .src(NODE_SRC)
-      .pipe(justLogErrors ? plumber() : noop())
-      .pipe(babel())
-      .pipe(gulp.dest(NODE_DEST));
-  };
+  return gulp
+    .src(NODE_SRC)
+    .pipe(babel())
+    .pipe(gulp.dest(NODE_DEST));
 }
 
 function compileViewerScripts() {

--- a/package.json
+++ b/package.json
@@ -66,8 +66,6 @@
     "exports-loader": "0.6.4",
     "gulp": "4.0.0",
     "gulp-babel": "7.0.1",
-    "gulp-noop": "1.0.0",
-    "gulp-plumber": "1.2.0",
     "mocha": "5.0.0",
     "nightmare": "2.10.0",
     "preact": "8.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,12 +131,6 @@ ansi-colors@^1.0.1:
   dependencies:
     ansi-wrap "^0.1.0"
 
-ansi-cyan@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz#538ae528af8982f28ae30d86f2f17456d2609873"
-  dependencies:
-    ansi-wrap "0.1.0"
-
 ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
@@ -150,12 +144,6 @@ ansi-gray@^0.1.1:
 ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-
-ansi-red@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz#8c638f9d1080800a353c9c28c8a81ca4705d946c"
-  dependencies:
-    ansi-wrap "0.1.0"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -220,13 +208,6 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-arr-diff@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
-  dependencies:
-    arr-flatten "^1.0.1"
-    array-slice "^0.2.3"
-
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -252,10 +233,6 @@ arr-map@^2.0.0, arr-map@^2.0.2:
   resolved "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz#3a77345ffc1cf35e2a91825601f9e58f2e24cac4"
   dependencies:
     make-iterator "^1.0.0"
-
-arr-union@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz#20f9eab5ec70f5c7d215b1077b1c39161d292c7d"
 
 arr-union@^3.1.0:
   version "3.1.0"
@@ -296,10 +273,6 @@ array-last@^1.1.1:
   resolved "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz#7aa77073fec565ddab2493f5f88185f404a9d336"
   dependencies:
     is-number "^4.0.0"
-
-array-slice@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
 
 array-slice@^1.0.0:
   version "1.1.0"
@@ -2437,12 +2410,6 @@ express@^4.16.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-extend-shallow@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz#19d6bf94dfc09d76ba711f39b872d21ff4dd9071"
-  dependencies:
-    kind-of "^1.1.0"
-
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -2977,21 +2944,6 @@ gulp-cli@^2.0.0:
     semver-greatest-satisfied-range "^1.1.0"
     v8flags "^3.0.1"
     yargs "^7.1.0"
-
-gulp-noop@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/gulp-noop/-/gulp-noop-1.0.0.tgz#082b1142493512ce5c5ab2e1ec3e7bb48b575c79"
-  dependencies:
-    through2 "^2.0.1"
-
-gulp-plumber@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.2.0.tgz#18ea03912c9ee483f8a5499973b5954cd90f6ad8"
-  dependencies:
-    chalk "^1.1.3"
-    fancy-log "^1.3.2"
-    plugin-error "^0.1.2"
-    through2 "^2.0.3"
 
 gulp@4.0.0:
   version "4.0.0"
@@ -3760,10 +3712,6 @@ keypress@0.1.x:
 killable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
-
-kind-of@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz#140a3d2d41a36d2efcfa9377b62c24f8495a5c44"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.1.0, kind-of@^3.2.0:
   version "3.2.2"
@@ -4732,16 +4680,6 @@ pkg-dir@^2.0.0:
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
-
-plugin-error@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz#3b9bb3335ccf00f425e07437e19276967da47ace"
-  dependencies:
-    ansi-cyan "^0.1.1"
-    ansi-red "^0.1.1"
-    arr-diff "^1.0.1"
-    arr-union "^2.0.1"
-    extend-shallow "^1.1.2"
 
 plugin-error@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
[This workaround](https://github.com/webpack-contrib/webpack-bundle-analyzer/compare/simplify-gulp-tasks?expand=1#diff-b9e12334e9eafd8341a6107dd98510c9R28) can be removed after https://github.com/gulpjs/glob-watcher/pull/34 is merged.