### PR TITLE
Fix parsing webpack 4's chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 <!-- Add changelog entries for new changes under this section -->
 
+ * **Improvement**
+   * Add support for parsing Webpack 4's chunked modules ([#159](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/159), [@jdelStrother](https://github.com/jdelStrother))
+
 ## 2.11.0
 
  * **Improvement**

--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -72,7 +72,7 @@ function parseBundle(bundlePath) {
         }
 
         // Additional bundles with webpack 4 are loaded with:
-        // (window.webpackJsonp=window.webpackJsonp||[]).push([[minimum ID], <module>, <module>]);
+        // (window.webpackJsonp=window.webpackJsonp||[]).push([[chunkId], [<module>, <module>], [[optional_entries]]]);
         if (
           isWindowPropertyPushExpression(node) &&
           args.length === 1 &&
@@ -129,6 +129,7 @@ function isArgumentContainsModulesList(arg) {
 function isArgumentContainingChunkIdsAndModulesList(arg) {
   if (
     arg.type === 'ArrayExpression' &&
+    arg.elements.length >= 2 &&
     isArgumentContainsChunkIds(arg.elements[0]) &&
     isArgumentContainsModulesList(arg.elements[1])
   ) {

--- a/test/bundles/validWebpack4Chunk.js
+++ b/test/bundles/validWebpack4Chunk.js
@@ -1,0 +1,1 @@
+(window.webpackJsonp=window.webpackJsonp||[]).push([[27],{"57iH":function(e,n,t){console.log("hello world")}}]);

--- a/test/bundles/validWebpack4Chunk.modules.json
+++ b/test/bundles/validWebpack4Chunk.modules.json
@@ -1,0 +1,5 @@
+{
+  "modules": {
+    "57iH": "function(e,n,t){console.log(\"hello world\")}"
+  }
+}

--- a/test/bundles/validWebpack4ChunkAndEntryPoint.js
+++ b/test/bundles/validWebpack4ChunkAndEntryPoint.js
@@ -1,0 +1,1 @@
+(window.webpackJsonp=window.webpackJsonp||[]).push([[27],{"57iH":function(e,n,t){console.log("hello world")}},[["57iH",19,24,25]]]);

--- a/test/bundles/validWebpack4ChunkAndEntryPoint.modules.json
+++ b/test/bundles/validWebpack4ChunkAndEntryPoint.modules.json
@@ -1,0 +1,5 @@
+{
+  "modules": {
+    "57iH": "function(e,n,t){console.log(\"hello world\")}"
+  }
+}


### PR DESCRIPTION
Webpack 4 has a new chunk loading style, looking something like this:

```js
(window.webpackJsonp=window.webpackJsonp||[]).push([[27],{"57iH":function(e,n,t){console.log("hello world")}}]);
```

WDYT to this approach?