### PR TITLE
Removed unnecessary folders from displaying in static analyzer file

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -124,11 +124,18 @@ function generateReport(bundleStats, opts) {
 
   if (!chartData) return;
 
+  const cleanChartData = chartData;
+  cleanChartData.forEach((bundle) => {
+    while (bundle.groups && bundle.groups.length === 1 && bundle.groups[0].groups) {
+      bundle.groups = bundle.groups[0].groups;
+    }
+  });
+
   ejs.renderFile(
     `${projectRoot}/views/viewer.ejs`,
     {
       mode: 'static',
-      chartData: JSON.stringify(chartData),
+      chartData: JSON.stringify(cleanChartData),
       assetContent: getAssetContent,
       defaultSizes: JSON.stringify(defaultSizes)
     },


### PR DESCRIPTION
Currently, some projects with several nested folders cause the entire display to be taken up by folder names instead of actual files. For example, the path to the components might look like './build/docs/components/repo1/src/component1/component1.js', and all the extra folders would be displayed. Now, unless a folder has multiple children, it will be hidden (but the full path to each file can still be seen by hovering over the file).