### PR TITLE
Proposal: allow bundle content retrieval to be customized in `parseBundle`

### DIFF
--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -7,8 +7,12 @@ module.exports = {
   parseBundle
 };
 
-function parseBundle(bundlePath) {
-  const content = fs.readFileSync(bundlePath, 'utf8');
+const defaultBundleHost = {
+  getFileContent: path => fs.readFileSync(path, 'utf8')
+};
+
+function parseBundle(bundlePath, bundleHost = defaultBundleHost) {
+  const content = bundleHost.getFileContent(bundlePath);
   const ast = acorn.parse(content, {
     sourceType: 'script',
     // I believe in a bright future of ECMAScript!

--- a/test/parseUtils.js
+++ b/test/parseUtils.js
@@ -30,4 +30,16 @@ describe('parseBundle', function () {
     expect(bundle.src).to.equal(fs.readFileSync(bundleFile, 'utf8'));
     expect(bundle.modules).to.deep.equal({});
   });
+
+  it('should allow a custom bundle host to override file system operations', function () {
+    let getBundleContentArg;
+    const bundle = parseBundle('arg', {
+      getFileContent: bundlePath => {
+        getBundleContentArg = bundlePath;
+        return 'webpackJsonp([0],[(t,e,r)=>{}])';
+      }
+    });
+    expect(getBundleContentArg).to.equal('arg');
+    expect(bundle.modules).to.deep.equal({0: '(t,e,r)=>{}'});
+  });
 });


### PR DESCRIPTION
I'm looking to use some parts of this project in a scenario where it's easiest to retrieve bundle files from a CDN rather than from the file system itself. I could download from the CDN to a temporary location, but by abstracting the `fs` calls to a “bundle host” object, I can feed the function a string from memory rather than relying on the file system itself. It would be even nicer if this function were async, and I could just tell the bundleHost to `fetch()` from the CDN, but I figured adding that complexity wouldn’t be warranted here.

At the moment, I only need `parseBundle`, and so only made changes there, but this approach could be used throughout the project, and I'd be open to making those changes if that would make this PR seem more appealing.

Thoughts? Thanks for this project and for the consideration!