### PR TITLE
Update README.md (#191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ ng build --stats-json --build-optimizer=false --vendor-chunk=true
 ```
 The resulting stats.json can be found at `dist/stats.json`
 
+*Please be aware, that this is not a reasonable build for production use, as it increases the build output size considerably.*
+
 ### I don't see `gzip` or `parsed` sizes, it only shows `stat` size
 
 It happens when `webpack-bundle-analyzer` analyzes files that don't actually exist in your file system, for example when you work with `webpack-dev-server` that keeps all the files in RAM. If you use `webpack-bundle-analyzer` as a plugin you won't get any errors, however if you run it via CLI you get the error message in terminal:
@@ -173,7 +175,6 @@ Analyzer will use module sizes from stats file.
 ```
 To get more information about it you can read [issue #147](https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/147).
 
-*Please be aware, that this is not a reasonable build for production use, as it increases the build output size considerably.*
 
 <h2 align="center">Maintainers</h2>
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ ng build --stats-json --build-optimizer=false --vendor-chunk=true
 ```
 The resulting stats.json can be found at `dist/stats.json`
 
+### I don't see `gzip` or `parsed` sizes, it only shows `stat` size
+
+It happens when `webpack-bundle-analyzer` analyzes files that don't actually exist in your file system, for example when you work with `webpack-dev-server` that keeps all the files in RAM. If you use `webpack-bundle-analyzer` as a plugin you won't get any errors, however if you run it via CLI you get the error message in terminal:
+```
+Couldn't parse bundle asset "your_bundle_name.bundle.js".
+Analyzer will use module sizes from stats file.
+```
+To get more information about it you can read [issue #147](https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/147).
+
 *Please be aware, that this is not a reasonable build for production use, as it increases the build output size considerably.*
 
 <h2 align="center">Maintainers</h2>

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ This module will help you:
 And the best thing is it supports minified bundles! It parses them to get real size of bundled modules.
 And it also shows their gzipped sizes!
 
-__IMPORTANT NOTE!__ Please keep in mind that it parses files that actually exists in the file system. If files are located in RAM (for example working with <a href="https://webpack.js.org/configuration/dev-server/" target="_blank" rel="nofollow">webpack-dev-server</a>) it only provides `stat` size value - `parsed` and `gzip` size values are not provided in this case.
-
 <h2 align="center">Options (for plugin)</h2>
 
 ```js

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This module will help you:
 And the best thing is it supports minified bundles! It parses them to get real size of bundled modules.
 And it also shows their gzipped sizes!
 
+__IMPORTANT NOTE!__ Please keep in mind that it parses files that actually exists in the file system. If files are located in RAM (for example working with <a href="https://webpack.js.org/configuration/dev-server/" target="_blank" rel="nofollow">webpack-dev-server</a>) it only provides `stat` size value - `parsed` and `gzip` size values are not provided in this case.
+
 <h2 align="center">Options (for plugin)</h2>
 
 ```js


### PR DESCRIPTION
Update information that plugin provides `parsed` and `gzip` size values only if files actually exist in the file system.

Closes #191 