### PR TITLE
feat: add brotli size support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Directory containing all generated bundles.
   -p, --port <n>              Port that will be used in `server` mode to start HTTP server. (default: 8888)
   -r, --report <file>         Path to bundle report file that will be generated in `static` mode. (default: report.html)
   -s, --default-sizes <type>  Module sizes to show in treemap by default.
-                              Possible values: stat, parsed, gzip (default: parsed)
+                              Possible values: stat, parsed, gzip, brotli (default: parsed)
   -O, --no-open               Don't open report in default browser automatically.
   -e, --exclude <regexp>      Assets that should be excluded from the report.
                               Can be specified multiple times.
@@ -147,6 +147,11 @@ as Uglify, then this value will reflect the minified size of your code.
 ### `gzip`
 
 This is the size of running the parsed bundles/modules through gzip compression.
+
+
+### `brotli`
+
+This is the size of running the parsed bundles/modules through brotli compression.
 
 <h2 align="center">Troubleshooting</h2>
 

--- a/client/components/ModulesTreemap.jsx
+++ b/client/components/ModulesTreemap.jsx
@@ -20,7 +20,8 @@ import ModulesList from './ModulesList';
 const SIZE_SWITCH_ITEMS = [
   {label: 'Stat', prop: 'statSize'},
   {label: 'Parsed', prop: 'parsedSize'},
-  {label: 'Gzipped', prop: 'gzipSize'}
+  {label: 'Gzipped', prop: 'gzipSize'},
+  {label: 'Brotli', prop: 'brotliSize'}
 ];
 
 @observer

--- a/client/store.js
+++ b/client/store.js
@@ -3,7 +3,7 @@ import {isChunkParsed, walkModules} from './utils';
 
 export class Store {
   cid = 0;
-  sizes = new Set(['statSize', 'parsedSize', 'gzipSize']);
+  sizes = new Set(['statSize', 'parsedSize', 'gzipSize', 'brotliSize']);
 
   @observable.ref allChunks;
   @observable.shallow selectedChunks;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1848,6 +1848,15 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "brotli-fsize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/brotli-fsize/-/brotli-fsize-1.0.2.tgz",
+      "integrity": "sha512-nKZSNZkmct5POgS+/kKuYERNqAS51Iz/kOMeOpX3Uv4B14CdDopziHASa0wTrcNPRaPU/qeg0UYn8E73jR7qZg==",
+      "requires": {
+        "duplexer": "^0.1.1",
+        "pify": "^3.0.0"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "acorn": "^5.7.3",
     "bfj": "^6.1.1",
+    "brotli-fsize": "^1.0.2",
     "chalk": "^2.4.1",
     "commander": "^2.18.0",
     "ejs": "^2.6.1",

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const _ = require('lodash');
 const gzipSize = require('gzip-size');
+const brotliSize = require('brotli-fsize');
 
 const Logger = require('./Logger');
 const Folder = require('./tree/Folder').default;
@@ -76,6 +77,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
     if (bundlesSources && _.has(bundlesSources, statAsset.name)) {
       asset.parsedSize = bundlesSources[statAsset.name].length;
       asset.gzipSize = gzipSize.sync(bundlesSources[statAsset.name]);
+      asset.brotliSize = brotliSize.sync(bundlesSources[statAsset.name]);
     }
 
     // Picking modules from current bundle script
@@ -100,6 +102,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
       statSize: asset.tree.size || asset.size,
       parsedSize: asset.parsedSize,
       gzipSize: asset.gzipSize,
+      brotliSize: asset.brotliSize,
       groups: _.invokeMap(asset.tree.children, 'toChartData')
     });
   }, []);

--- a/src/tree/ContentFolder.js
+++ b/src/tree/ContentFolder.js
@@ -15,6 +15,10 @@ export default class ContentFolder extends BaseFolder {
     return this.getSize('gzipSize');
   }
 
+  get brotliSize() {
+    return this.getSize('brotliSize');
+  }
+
   getSize(sizeType) {
     const ownerModuleSize = this.ownerModule[sizeType];
 
@@ -28,6 +32,7 @@ export default class ContentFolder extends BaseFolder {
       ...super.toChartData(),
       parsedSize: this.parsedSize,
       gzipSize: this.gzipSize,
+      brotliSize: this.brotliSize,
       inaccurateSizes: true
     };
   }

--- a/src/tree/ContentModule.js
+++ b/src/tree/ContentModule.js
@@ -15,6 +15,10 @@ export default class ContentModule extends Module {
     return this.getSize('gzipSize');
   }
 
+  get brotliSize() {
+    return this.getSize('brotliSize');
+  }
+
   getSize(sizeType) {
     const ownerModuleSize = this.ownerModule[sizeType];
 

--- a/src/tree/Folder.js
+++ b/src/tree/Folder.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import gzipSize from 'gzip-size';
+import brotliSize from 'brotli-fsize';
 
 import Module from './Module';
 import BaseFolder from './BaseFolder';
@@ -18,6 +19,14 @@ export default class Folder extends BaseFolder {
     }
 
     return this._gzipSize;
+  }
+
+  get brotliSize() {
+    if (!_.has(this, '_brotliSize')) {
+      this._brotliSize = this.src ? brotliSize.sync(this.src) : 0;
+    }
+
+    return this._brotliSize;
   }
 
   addModule(moduleData) {
@@ -57,7 +66,8 @@ export default class Folder extends BaseFolder {
     return {
       ...super.toChartData(),
       parsedSize: this.parsedSize,
-      gzipSize: this.gzipSize
+      gzipSize: this.gzipSize,
+      brotliSize: this.brotliSize
     };
   }
 

--- a/src/tree/Module.js
+++ b/src/tree/Module.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import gzipSize from 'gzip-size';
+import brotliSize from 'brotli-fsize';
 
 import Node from './Node';
 
@@ -39,6 +40,14 @@ export default class Module extends Node {
     return this._gzipSize;
   }
 
+  get brotliSize() {
+    if (!_.has(this, '_brotliSize')) {
+      this._brotliSize = this.src ? brotliSize.sync(this.src) : undefined;
+    }
+
+    return this._brotliSize;
+  }
+
   mergeData(data) {
     if (data.size) {
       this.size += data.size;
@@ -56,7 +65,8 @@ export default class Module extends Node {
       path: this.path,
       statSize: this.size,
       parsedSize: this.parsedSize,
-      gzipSize: this.gzipSize
+      gzipSize: this.gzipSize,
+      brotliSize: this.brotliSize
     };
   }
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -33,7 +33,8 @@ describe('Plugin', function () {
 
     await expectValidReport({
       parsedSize: 1343,
-      gzipSize: 360
+      gzipSize: 360,
+      brotliSize: 304
     });
   });
 
@@ -81,7 +82,8 @@ async function expectValidReport(opts) {
     bundleLabel = 'bundle.js',
     statSize = 141,
     parsedSize = 2821,
-    gzipSize = 770
+    gzipSize = 770,
+    brotliSize = 560
   } = opts || {};
 
   expect(fs.existsSync(`${__dirname}/output/${bundleFilename}`), 'bundle file missing').to.be.true;
@@ -91,7 +93,8 @@ async function expectValidReport(opts) {
     label: bundleLabel,
     statSize,
     parsedSize,
-    gzipSize
+    gzipSize,
+    brotliSize
   });
 }
 


### PR DESCRIPTION
Hey :wave:

As native Brotli support landed in the latest minor Node version, I thought it wouldn't hurt to file a PR that leverages the support to calculate Brotli sizes (similar to #114 but with the native implementation used). I approached the problem similar to the GZIP implementation (using the Brotli version of [gzip-size](https://github.com/sindresorhus/gzip-size#readme) called [brotli-fsize](https://github.com/Developmint/brotli-fsize/).

## Problems

As the **native implementation** is only present in Node 11.7.0 and upwards (might be backported to the LTS at on day but even this doesn't support Node <= 10.X) and the used package explicitly asks for the version, I'm not sure how to deal with lower Node versions here.

I could remove the strict version requirements and check the node version in this package instead but this seems more like a hacky solution.

I'm waiting for your feedback/ideas :relaxed: 

Resolves #113 
