### PR TITLE
Make webpack's done hook wait until analyzer writes report / stat file.

### DIFF
--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -34,6 +34,7 @@ class BundleAnalyzerPlugin {
     this.compiler = compiler;
 
     const done = (stats, callback) => {
+      callback = callback || (() => {});
       stats = stats.toJson(this.opts.statsOptions);
 
       const actions = [];
@@ -57,14 +58,14 @@ class BundleAnalyzerPlugin {
         // Making analyzer logs to be after all webpack logs in the console
         setImmediate(async () => {
           try {
-            for (let i = 0; i < actions.length; ++i) await actions[i]();
-            if (typeof callback === 'function') callback();
+            await Promise.all(actions.map(action => action()));
+            callback();
           } catch (e) {
-            if (typeof callback === 'function') callback(e);
+            callback(e);
           }
         });
       } else {
-        if (typeof callback === 'function') callback();
+        callback();
       }
     };
 

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -57,12 +57,14 @@ class BundleAnalyzerPlugin {
         // Making analyzer logs to be after all webpack logs in the console
         setImmediate(async () => {
           try {
-            for (let i = 0, len = actions.length; i < len; ++i) await actions[i]();
+            for (let i = 0; i < actions.length; ++i) await actions[i]();
             if (typeof callback === 'function') callback();
           } catch (e) {
             if (typeof callback === 'function') callback(e);
           }
         });
+      } else {
+        if (typeof callback === 'function') callback();
       }
     };
 

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -58,9 +58,9 @@ class BundleAnalyzerPlugin {
         setImmediate(async () => {
           try {
             for (let i = 0, len = actions.length; i < len; ++i) await actions[i]();
-            if (typeof callback === "function") callback();
+            if (typeof callback === 'function') callback();
           } catch (e) {
-            if (typeof callback === "function") callback(e);
+            if (typeof callback === 'function') callback(e);
           }
         });
       }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -142,16 +142,16 @@ async function generateReport(bundleStats, opts) {
             reject(err);
             return;
           }
-    
+
           const reportFilepath = path.resolve(bundleDir || process.cwd(), reportFilename);
-    
+
           mkdir.sync(path.dirname(reportFilepath));
           fs.writeFileSync(reportFilepath, reportHtml);
-    
+
           logger.info(
             `${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilepath)}`
           );
-    
+
           if (openBrowser) {
             opener(`file://${reportFilepath}`);
           }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -111,7 +111,7 @@ async function startServer(bundleStats, opts) {
   }
 }
 
-function generateReport(bundleStats, opts) {
+async function generateReport(bundleStats, opts) {
   const {
     openBrowser = true,
     reportFilename = 'report.html',
@@ -125,32 +125,43 @@ function generateReport(bundleStats, opts) {
 
   if (!chartData) return;
 
-  ejs.renderFile(
-    `${projectRoot}/views/viewer.ejs`,
-    {
-      mode: 'static',
-      chartData: JSON.stringify(chartData),
-      assetContent: getAssetContent,
-      defaultSizes: JSON.stringify(defaultSizes),
-      enableWebSocket: false
-    },
-    (err, reportHtml) => {
-      if (err) return logger.error(err);
-
-      const reportFilepath = path.resolve(bundleDir || process.cwd(), reportFilename);
-
-      mkdir.sync(path.dirname(reportFilepath));
-      fs.writeFileSync(reportFilepath, reportHtml);
-
-      logger.info(
-        `${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilepath)}`
-      );
-
-      if (openBrowser) {
-        opener(`file://${reportFilepath}`);
+  await new Promise((resolve, reject) => {
+    ejs.renderFile(
+      `${projectRoot}/views/viewer.ejs`,
+      {
+        mode: 'static',
+        chartData: JSON.stringify(chartData),
+        assetContent: getAssetContent,
+        defaultSizes: JSON.stringify(defaultSizes),
+        enableWebSocket: false
+      },
+      (err, reportHtml) => {
+        try {
+          if (err) {
+            logger.error(err);
+            reject(err);
+            return;
+          }
+    
+          const reportFilepath = path.resolve(bundleDir || process.cwd(), reportFilename);
+    
+          mkdir.sync(path.dirname(reportFilepath));
+          fs.writeFileSync(reportFilepath, reportHtml);
+    
+          logger.info(
+            `${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilepath)}`
+          );
+    
+          if (openBrowser) {
+            opener(`file://${reportFilepath}`);
+          }
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
       }
-    }
-  );
+    );
+  });
 }
 
 function getAssetContent(filename) {


### PR DESCRIPTION
Fixes #232 by prolonging webpack's "done" hook until analyzer finishes writing report / stat files.