### PR TITLE
Update acorn to version 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1107,9 +1107,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.7.tgz",
+      "integrity": "sha512-HNJNgE60C9eOTgn974Tlp3dpLZdUr+SoxxDwPaY9J/kDNOLQTkaDgwBUXAF4SSsrAwD9RpdxuHK/EbuF+W9Ahw=="
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
@@ -1118,6 +1118,14 @@
       "dev": true,
       "requires": {
         "acorn": "^5.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
       }
     },
     "acorn-jsx": {
@@ -1136,6 +1144,11 @@
           "dev": true
         }
       }
+    },
+    "acorn-walk": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
     },
     "ajv": {
       "version": "5.5.2",
@@ -3633,6 +3646,14 @@
       "requires": {
         "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -10464,6 +10485,12 @@
         "webpack-sources": "^1.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        },
         "ajv": {
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "views"
   ],
   "dependencies": {
-    "acorn": "^5.7.3",
+    "acorn": "^6.0.7",
+    "acorn-walk": "^6.1.1",
     "bfj": "^6.1.1",
     "chalk": "^2.4.1",
     "commander": "^2.18.0",

--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const _ = require('lodash');
 const acorn = require('acorn');
-const walk = require('acorn/dist/walk');
+const walk = require('acorn-walk');
 
 module.exports = {
   parseBundle


### PR DESCRIPTION
Fixes #245

Supporting both acorn 5 and acorn 6 is not feasible because `acorn-walk` got split into its own module.