### PR TITLE
Prepare next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 <!-- Add changelog entries for new changes under this section -->
 
+* **Bug Fix**
+  * Make webpack's done hook wait until analyzer writes report or stat file ([#247](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/247), [@mareolan](https://github.com/mareolan))
+
 ## 3.0.3
 
 * **Bug Fix**


### PR DESCRIPTION
This release would contain these pull requests:

* https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/222
* https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/227
* https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/231
* https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/234
* https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/247

I think this would mean a patch version bump. I could release a new version with these pull requests if that's OK to you, @th0r?