### PR TITLE
Fix positioning of the context menu when sidebar is pinned

### DIFF
--- a/client/components/ModulesTreemap.jsx
+++ b/client/components/ModulesTreemap.jsx
@@ -26,6 +26,11 @@ const SIZE_SWITCH_ITEMS = [
 
 @observer
 export default class ModulesTreemap extends Component {
+  mouseCoords = {
+    x: 0,
+    y: 0
+  };
+
   state = {
     selectedChunk: null,
     selectedMouseCoords: {x: 0, y: 0},
@@ -34,6 +39,14 @@ export default class ModulesTreemap extends Component {
     showTooltip: false,
     tooltipContent: null
   };
+
+  componentDidMount() {
+    document.addEventListener('mousemove', this.handleMouseMove, true);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousemove', this.handleMouseMove, true);
+  }
 
   render() {
     const {
@@ -245,14 +258,12 @@ export default class ModulesTreemap extends Component {
   };
 
   handleTreemapGroupSecondaryClick = event => {
-    const {group, x, y} = event;
+    const {group} = event;
+
     if (group && group.isAsset) {
       this.setState({
         selectedChunk: group,
-        selectedMouseCoords: {
-          x,
-          y
-        },
+        selectedMouseCoords: {...this.mouseCoords},
         showChunkContextMenu: true
       });
     } else {
@@ -277,6 +288,13 @@ export default class ModulesTreemap extends Component {
   };
 
   handleFoundModuleClick = module => this.treemap.zoomToGroup(module);
+
+  handleMouseMove = event => {
+    Object.assign(this.mouseCoords, {
+      x: event.pageX,
+      y: event.pageY
+    });
+  }
 
   isModuleVisible = module => (
     this.treemap.isGroupRendered(module)

--- a/client/components/Tooltip.jsx
+++ b/client/components/Tooltip.jsx
@@ -9,22 +9,18 @@ export default class Tooltip extends Component {
   static marginX = 10;
   static marginY = 30;
 
-  constructor(props) {
-    super(props);
+  mouseCoords = {
+    x: 0,
+    y: 0
+  };
 
-    this.mouseCoords = {
-      x: 0,
-      y: 0
-    };
-
-    this.state = {
-      left: 0,
-      top: 0
-    };
-  }
+  state = {
+    left: 0,
+    top: 0
+  };
 
   componentDidMount() {
-    document.addEventListener('mousemove', this.onMouseMove, false);
+    document.addEventListener('mousemove', this.handleMouseMove, true);
   }
 
   shouldComponentUpdate(nextProps) {
@@ -32,7 +28,7 @@ export default class Tooltip extends Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousemove', this.onMouseMove);
+    document.removeEventListener('mousemove', this.handleMouseMove, true);
   }
 
   render() {
@@ -50,6 +46,17 @@ export default class Tooltip extends Component {
       </div>
     );
   }
+
+  handleMouseMove = event => {
+    Object.assign(this.mouseCoords, {
+      x: event.pageX,
+      y: event.pageY
+    });
+
+    if (this.props.visible) {
+      this.updatePosition();
+    }
+  };
 
   saveNode = node => (this.node = node);
 
@@ -82,16 +89,5 @@ export default class Tooltip extends Component {
 
     this.setState(pos);
   }
-
-  onMouseMove = event => {
-    Object.assign(this.mouseCoords, {
-      x: event.pageX,
-      y: event.pageY
-    });
-
-    if (this.props.visible) {
-      this.updatePosition();
-    }
-  };
 
 }


### PR DESCRIPTION
`x` and `y` coordinates of the FoamTree [click event](https://get.carrotsearch.com/foamtree/demo/api/index.html#event-details) are relative to the visualization container element so we can't rely on them when sidebar is pinned.