### PR TITLE
Add CSS autoprefixer (resolves #255)

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,5 @@
+# Supported browsers
+
+last 2 Chrome major versions
+last 2 Firefox major versions
+last 1 Safari major version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1585,6 +1585,20 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "autoprefixer": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
+      "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.5.4",
+        "caniuse-lite": "^1.0.30000957",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.14",
+        "postcss-value-parser": "^3.3.1"
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -7026,6 +7040,12 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
     "normalize-url": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
@@ -7081,6 +7101,12 @@
           "dev": true
         }
       }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@babel/preset-react": "7.0.0",
     "@babel/register": "7.4.0",
     "@babel/runtime": "7.4.3",
+    "autoprefixer": "9.5.1",
     "babel-eslint": "10.0.1",
     "babel-loader": "8.0.5",
     "babel-plugin-lodash": "3.3.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,11 +61,8 @@ module.exports = opts => {
             babelrc: false,
             presets: [
               ['@babel/preset-env', {
-                targets: [
-                  'last 2 Chrome major versions',
-                  'last 2 Firefox major versions',
-                  'last 1 Safari major version'
-                ],
+                // Target browsers are specified in .browserslistrc
+
                 modules: false,
                 useBuiltIns: 'usage',
                 corejs: 2,
@@ -105,6 +102,7 @@ module.exports = opts => {
               options: {
                 plugins: compact([
                   require('postcss-icss-values'),
+                  require('autoprefixer'),
                   !isDev && require('cssnano')()
                 ])
               }


### PR DESCRIPTION
This adds [`autoprefixer`](https://github.com/postcss/autoprefixer) for CSS prefixing. (Which is a follow-up re: PR review feedback in https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/246#discussion_r272921108 / #255).

As part of making this change, I moved the [browserslist](https://github.com/browserslist/browserslist) config that was specified inline in the Webpack config out to a `.browserslistrc` file (it could just as well be added as a `browserslist` key to `package.json` -- could go either way on that personally), so that the same browser list will be used by `babel-preset-env` and `autoprefixer` / other `postcss` plugins.

This build config change currently only results in a tiny difference to the generated browser JS bundle: it adds prefixes to the two places `user-select` CSS rules are used (it turns out no other rules need prefixing currently).

```diff
-     (t = e.exports = n(2)(!1)).push([e.i, ".ContextMenuItem__item{cursor:pointer;margin:0;padding:8px 14px;user-select:none}.ContextMenuItem__item:hover{background:#ffefd7}.ContextMenuItem__disabled{cursor:default;color:grey}.ContextMenuItem__item.ContextMenuItem__disabled:hover{background:transparent}", ""]), t.locals = {
+     (t = e.exports = n(2)(!1)).push([e.i, ".ContextMenuItem__item{cursor:pointer;margin:0;padding:8px 14px;-webkit-user-select:none;-moz-user-select:none;user-select:none}.ContextMenuItem__item:hover{background:#ffefd7}.ContextMenuItem__disabled{cursor:default;color:grey}.ContextMenuItem__item.ContextMenuItem__disabled:hover{background:transparent}", ""]), t.locals = {
...
-     (e.exports = n(2)(!1)).push([e.i, ":root{--main-font:normal 11px Verdana}#app,body,html{height:100%;margin:0;overflow:hidden;padding:0;width:100%}body.resizing{user-select:none!important}body.resizing *{pointer-events:none}body.resizing.col{cursor:col-resize!important}", ""])
+     (e.exports = n(2)(!1)).push([e.i, ":root{--main-font:normal 11px Verdana}#app,body,html{height:100%;margin:0;overflow:hidden;padding:0;width:100%}body.resizing{-webkit-user-select:none!important;-moz-user-select:none!important;user-select:none!important}body.resizing *{pointer-events:none}body.resizing.col{cursor:col-resize!important}", ""])
```

(If you use Glitch you can visit https://glitch.com/edit/#!/comparewebpackbuildoutput?path=README.md:17:168 to quickly generate a diff like the above to confirm that only the two lines above are affected; the non-CSS JS build output remains the same, showing that nothing seems to have broken when moving around the browserslist config, and that the prefixing is not overly aggressive)