### PR TITLE
Add AsyncMFS for getBundleDirFromCompiler

### DIFF
--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -130,7 +130,7 @@ class BundleAnalyzerPlugin {
   getBundleDirFromCompiler() {
     switch (this.compiler.outputFileSystem.constructor.name) {
       case 'MemoryFileSystem':
-        
+        return null;
       // Detect AsyncMFS used by Nuxt 2.5 that replaces webpack's MFS during development
       // Related: #274
       case 'AsyncMFS':

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -128,7 +128,13 @@ class BundleAnalyzerPlugin {
   }
 
   getBundleDirFromCompiler() {
-    return (this.compiler.outputFileSystem.constructor.name === 'MemoryFileSystem') ? null : this.compiler.outputPath;
+    switch (this.compiler.outputFileSystem.constructor.name) {
+      case 'MemoryFileSystem':
+      case 'AsyncMFS':
+        return null;
+      default:
+        return this.compiler.outputPath;
+    }
   }
 
 }

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -130,6 +130,9 @@ class BundleAnalyzerPlugin {
   getBundleDirFromCompiler() {
     switch (this.compiler.outputFileSystem.constructor.name) {
       case 'MemoryFileSystem':
+        
+      // Detect AsyncMFS used by Nuxt 2.5 that replaces webpack's MFS during development
+      // Related: #274
       case 'AsyncMFS':
         return null;
       default:


### PR DESCRIPTION
### Details
- Detect `AsyncMFS` to support dev-server of Nuxt 2.5 and above

### Related issues
- #274 