### PR TITLE
Allow overwriting of `bundleDir` via `bundleDirOption` from plugin option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ new BundleAnalyzerPlugin(options?: object)
 |**`analyzerMode`**|One of: `server`, `static`, `disabled`|Default: `server`. In `server` mode analyzer will start HTTP server to show bundle report. In `static` mode single HTML file with bundle report will be generated. In `disabled` mode you can use this plugin to just generate Webpack Stats JSON file by setting `generateStatsFile` to `true`. |
 |**`analyzerHost`**|`{String}`|Default: `127.0.0.1`. Host that will be used in `server` mode to start HTTP server.|
 |**`analyzerPort`**|`{Number}`|Default: `8888`. Port that will be used in `server` mode to start HTTP server.|
+|**`bundleDirOption`**|`{null|Boolean|String}`|Default: `null`. Option defining the directory containing all generated bundles. If `null`, make `bundleDir` to be `compiler.outputPath`, or `null` if webpack-dev-server is used. otherwise if `false`, `bundleDir` will be `null`. Else, provided `bundleDirOption` will be used as `bundleDir` |
 |**`reportFilename`**|`{String}`|Default: `report.html`. Path to bundle report file that will be generated in `static` mode. It can be either an absolute path or a path relative to a bundle output directory (which is output.path in webpack config).|
 |**`defaultSizes`**|One of: `stat`, `parsed`, `gzip`|Default: `parsed`. Module sizes to show in report by default. [Size definitions](#size-definitions) section describes what these values mean.|
 |**`openAnalyzer`**|`{Boolean}`|Default: `true`. Automatically open report in default browser.|

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -130,7 +130,7 @@ class BundleAnalyzerPlugin {
 
   getBundleDir(bundleDirOption) {
     if (bundleDirOption == null) { // bundleDirOption is not provided
-      return getBundleDirFromCompiler();
+      return this.getBundleDirFromCompiler();
 
     } else if (bundleDirOption === false) { // bundleDirOption is explicitly turned off
       return null;

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -129,10 +129,12 @@ class BundleAnalyzerPlugin {
   }
 
   getBundleDir(bundleDirOption) {
-    if (bundleDirOption == null) { // bundleDirOption is not provided
+    // bundleDirOption is not provided
+    if (bundleDirOption == null) {
       return this.getBundleDirFromCompiler();
 
-    } else if (bundleDirOption === false) { // bundleDirOption is explicitly turned off
+    // bundleDirOption is explicitly turned off
+    } else if (bundleDirOption === false) {
       return null;
     }
 

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -13,7 +13,7 @@ class BundleAnalyzerPlugin {
       analyzerMode: 'server',
       analyzerHost: '127.0.0.1',
       analyzerPort: 8888,
-      bundleDir: null,
+      bundleDirOption: null,
       reportFilename: 'report.html',
       defaultSizes: 'parsed',
       openAnalyzer: true,
@@ -109,7 +109,7 @@ class BundleAnalyzerPlugin {
         openBrowser: this.opts.openAnalyzer,
         host: this.opts.analyzerHost,
         port: this.opts.analyzerPort,
-        bundleDir: this.getBundleDir(this.opts.bundleDir),
+        bundleDir: this.getBundleDir(this.opts.bundleDirOption),
         logger: this.logger,
         defaultSizes: this.opts.defaultSizes,
         excludeAssets: this.opts.excludeAssets
@@ -121,22 +121,22 @@ class BundleAnalyzerPlugin {
     await viewer.generateReport(stats, {
       openBrowser: this.opts.openAnalyzer,
       reportFilename: path.resolve(this.compiler.outputPath, this.opts.reportFilename),
-      bundleDir: this.getBundleDir(this.opts.bundleDir),
+      bundleDir: this.getBundleDir(this.opts.bundleDirOption),
       logger: this.logger,
       defaultSizes: this.opts.defaultSizes,
       excludeAssets: this.opts.excludeAssets
     });
   }
 
-  getBundleDir(bundleDirOpts) {
-    if (bundleDirOpts == null) { // bundleDirOpts is not provided
+  getBundleDir(bundleDirOption) {
+    if (bundleDirOption == null) { // bundleDirOption is not provided
       return getBundleDirFromCompiler();
 
-    } else if (bundleDirOpts === false) { // bundleDirOpts is explicitly turned off
+    } else if (bundleDirOption === false) { // bundleDirOption is explicitly turned off
       return null;
     }
 
-    return bundleDirOpts;
+    return bundleDirOption;
   }
 
   getBundleDirFromCompiler() {

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -13,6 +13,7 @@ class BundleAnalyzerPlugin {
       analyzerMode: 'server',
       analyzerHost: '127.0.0.1',
       analyzerPort: 8888,
+      bundleDir: null,
       reportFilename: 'report.html',
       defaultSizes: 'parsed',
       openAnalyzer: true,
@@ -108,7 +109,7 @@ class BundleAnalyzerPlugin {
         openBrowser: this.opts.openAnalyzer,
         host: this.opts.analyzerHost,
         port: this.opts.analyzerPort,
-        bundleDir: this.getBundleDirFromCompiler(),
+        bundleDir: this.getBundleDir(this.opts.bundleDir),
         logger: this.logger,
         defaultSizes: this.opts.defaultSizes,
         excludeAssets: this.opts.excludeAssets
@@ -120,11 +121,22 @@ class BundleAnalyzerPlugin {
     await viewer.generateReport(stats, {
       openBrowser: this.opts.openAnalyzer,
       reportFilename: path.resolve(this.compiler.outputPath, this.opts.reportFilename),
-      bundleDir: this.getBundleDirFromCompiler(),
+      bundleDir: this.getBundleDir(this.opts.bundleDir),
       logger: this.logger,
       defaultSizes: this.opts.defaultSizes,
       excludeAssets: this.opts.excludeAssets
     });
+  }
+
+  getBundleDir(bundleDirOpts) {
+    if (bundleDirOpts == null) { // bundleDirOpts is not provided
+      return getBundleDirFromCompiler();
+
+    } else if (bundleDirOpts === false) { // bundleDirOpts is explicitly turned off
+      return null;
+    }
+
+    return bundleDirOpts;
   }
 
   getBundleDirFromCompiler() {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -71,6 +71,64 @@ describe('Plugin', function () {
         expect(_.map(chartData, 'label')).to.deep.equal(['bundle.js']);
       });
     });
+
+    describe('bundleDirOption', function () {
+      it('should report parsedSize and gzipSize when bundleDirOption is not provided', async function () {
+        const config = makeWebpackConfig({
+          analyzerOpts: {
+          }
+        });
+
+        await webpackCompile(config);
+
+        const chartData = await getChartDataFromReport();
+        expect(
+          chartData[0].groups.every(group => (
+            ('parsedSize' in group)
+            && ('gzipSize' in group)
+            && ('statSize' in group)
+          ))
+        ).to.be.true;
+      });
+
+      it('should report parsedSize and gzipSize when bundleDirOption is null', async function () {
+        const config = makeWebpackConfig({
+          analyzerOpts: {
+            bundleDirOption: null
+          }
+        });
+
+        await webpackCompile(config);
+
+        const chartData = await getChartDataFromReport();
+        expect(
+          chartData[0].groups.every(group => (
+            ('parsedSize' in group)
+            && ('gzipSize' in group)
+            && ('statSize' in group)
+          ))
+        ).to.be.true;
+      });
+
+      it('should report statSize only bundleDirOption is false', async function () {
+        const config = makeWebpackConfig({
+          analyzerOpts: {
+            bundleDirOption: false
+          }
+        });
+
+        await webpackCompile(config);
+
+        const chartData = await getChartDataFromReport();
+        expect(
+          chartData[0].groups.every(group => (
+            !group.parsedSize
+            && !group.gzipSize
+            && group.statSize
+          ))
+        ).to.be.true;
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Details
- Allow overwriting of `bundleDir` via `bundleDirOption` from plugin option.
- Updated documentation for `bundleDirOption`
- Added 3 tests for `bundleDirOption`

```
  Plugin
    options
      bundleDirOption
        √ should report parsedSize and gzipSize when bundleDirOption is not provided (269ms)
        √ should report parsedSize and gzipSize when bundleDirOption is null (264ms)
        √ should report statSize only bundleDirOption is false (270ms)
```

### Related issues
- #274 