### PR TITLE
Add support for 'auto' option with analyzer port #281

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ new BundleAnalyzerPlugin(options?: object)
 |:--:|:--:|:----------|
 |**`analyzerMode`**|One of: `server`, `static`, `disabled`|Default: `server`. In `server` mode analyzer will start HTTP server to show bundle report. In `static` mode single HTML file with bundle report will be generated. In `disabled` mode you can use this plugin to just generate Webpack Stats JSON file by setting `generateStatsFile` to `true`. |
 |**`analyzerHost`**|`{String}`|Default: `127.0.0.1`. Host that will be used in `server` mode to start HTTP server.|
-|**`analyzerPort`**|`{Number}`|Default: `8888`. Port that will be used in `server` mode to start HTTP server.|
+|**`analyzerPort`**|`{Number}` or `auto`|Default: `8888`. Port that will be used in `server` mode to start HTTP server.|
 |**`reportFilename`**|`{String}`|Default: `report.html`. Path to bundle report file that will be generated in `static` mode. It can be either an absolute path or a path relative to a bundle output directory (which is output.path in webpack config).|
 |**`defaultSizes`**|One of: `stat`, `parsed`, `gzip`|Default: `parsed`. Module sizes to show in report by default. [Size definitions](#size-definitions) section describes what these values mean.|
 |**`openAnalyzer`**|`{Boolean}`|Default: `true`. Automatically open report in default browser.|
@@ -115,7 +115,7 @@ Directory containing all generated bundles.
                               In `server` mode analyzer will start HTTP server to show bundle report.
                               In `static` mode single HTML file with bundle report will be generated. (default: server)
   -h, --host <host>           Host that will be used in `server` mode to start HTTP server. (default: 127.0.0.1)
-  -p, --port <n>              Port that will be used in `server` mode to start HTTP server. (default: 8888)
+  -p, --port <n>              Port that will be used in `server` mode to start HTTP server. Should be a number or `auto` (default: 8888)
   -r, --report <file>         Path to bundle report file that will be generated in `static` mode. (default: report.html)
   -s, --default-sizes <type>  Module sizes to show in treemap by default.
                               Possible values: stat, parsed, gzip (default: parsed)

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -12,7 +12,6 @@ class BundleAnalyzerPlugin {
     this.opts = {
       analyzerMode: 'server',
       analyzerHost: '127.0.0.1',
-      analyzerPort: 8888,
       reportFilename: 'report.html',
       defaultSizes: 'parsed',
       openAnalyzer: true,
@@ -23,7 +22,8 @@ class BundleAnalyzerPlugin {
       logLevel: 'info',
       // deprecated
       startAnalyzer: true,
-      ...opts
+      ...opts,
+      analyzerPort: 'analyzerPort' in opts ? (opts.analyzerPort === 'auto' ? 0 : opts.analyzerPort) : 8888
     };
 
     this.server = null;

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -41,7 +41,6 @@ const program = commander
   .option(
     '-p, --port <n>',
     'Port that will be used in `server` mode to start HTTP server.',
-    Number,
     8888
   )
   .option(
@@ -88,8 +87,12 @@ const logger = new Logger(logLevel);
 
 if (!bundleStatsFile) showHelp('Provide path to Webpack Stats file as first argument');
 if (mode !== 'server' && mode !== 'static') showHelp('Invalid mode. Should be either `server` or `static`.');
-if (mode === 'server' && !host) showHelp('Invalid host name');
-if (mode === 'server' && isNaN(port)) showHelp('Invalid port number');
+if (mode === 'server') {
+  if (!host) showHelp('Invalid host name');
+
+  port = port === 'auto' ? 0 : Number(port);
+  if (isNaN(port)) showHelp('Invalid port. Should be a number or `auto`');
+}
 if (!SIZES.has(defaultSizes)) showHelp(`Invalid default sizes option. Possible values are: ${[...SIZES].join(', ')}`);
 
 bundleStatsFile = resolve(bundleStatsFile);


### PR DESCRIPTION
It's a single line of quite self-explanatory code. But I'm happy to write tests, just not sure where.

The logic I went with was, if analyzer port is specified, (and) if it is 'auto' use 0, else use the specified value. If it is not specified, use 8888, the default.

Closes #281 
