### PR TITLE
fix: solved the error — options is required

### DIFF
--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -8,7 +8,7 @@ const viewer = require('./viewer');
 
 class BundleAnalyzerPlugin {
 
-  constructor(opts) {
+  constructor(opts = {}) {
     this.opts = {
       analyzerMode: 'server',
       analyzerHost: '127.0.0.1',


### PR DESCRIPTION
add a default value for BundleAnalyzerPlugin's options
fixes #300