### PR TITLE
Fix case where checked bundles in sidebar don't update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 <!-- Add changelog entries for new changes under this section -->
 
+ * **Bug Fix**
+   * Fix sidebar not showing visibility status of chunks hidden via popup menu (issue [#316](https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/316) by [@gaokun](https://github.com/gaokun), fixed in [#317](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/317) by [@bregenspan](https://github.com/bregenspan))
+
 ## 3.5.1
 
  * **Bug Fix**

--- a/client/components/CheckboxList.jsx
+++ b/client/components/CheckboxList.jsx
@@ -33,6 +33,8 @@ export default class CheckboxList extends PureComponent {
         this.setState({checkedItems});
         this.informAboutChange(checkedItems);
       }
+    } else if (newProps.checkedItems !== this.props.checkedItems) {
+      this.setState({checkedItems: newProps.checkedItems});
     }
   }
 


### PR DESCRIPTION
Fixes #316

The relevant piece of state here is derived from props, and was failing to update upon prop update in the particular case noted in #316.

One thought re: preventing this class of bug in future is to centralize the state management logic that handles whether all bundles are showing, putting it in the shared MobX store (and eliminating use of state derived from props). I might have time to explore this in a separate PR, but I think this quick fix is probably better for now.

### Notes re: manual testing
Because the `componentWillReceiveProps` handler appears to have been added for <a href="https://github.com/bregenspan/webpack-bundle-analyzer/commit/279bb2638f1cddf04b319966c71565c48d874f3a">`webpack --watch`</a> support, I tested that the watch mode/dev server compatibility still functions as expected after this change by adding and removing bundles to a running webpack-dev-server. The checkbox state behaved as expected:

 * in the case where all checkboxes were checked before the new bundle was added, the new bundle is added in checked state
 * in the case where not all checkboxes were checked before the new bundle was added, the new bundle is not added in checked state