### PR TITLE
Improved readability: fixed serif font and tooltip opacity

### DIFF
--- a/client/components/Tooltip.css
+++ b/client/components/Tooltip.css
@@ -5,7 +5,7 @@
   border-radius: 4px;
   background: #fff;
   border: 1px solid #aaa;
-  opacity: 0.7;
+  opacity: 0.9;
   white-space: nowrap;
   visibility: visible;
   transition: opacity .2s ease, visibility .2s ease;

--- a/client/viewer.css
+++ b/client/viewer.css
@@ -1,5 +1,5 @@
 :root {
-  --main-font: normal 11px Verdana;
+  --main-font: normal 11px Verdana, sans-serif;
 }
 
 :global html,


### PR DESCRIPTION
On my system there's no [`Verdana` font](https://github.com/webpack-contrib/webpack-bundle-analyzer/blob/d7682a655abda824c82b9d6bb7991b9576c33610/client/viewer.css#L2), therefore sidebar and tooltips are displayed with the ugly default serif font. I added an explicit `sans-serif` fallback for the `--main-font` CSS variable, to make the system use the non-serif default font, at least.

I also increased the [opacity of tooltips](https://github.com/webpack-contrib/webpack-bundle-analyzer/blob/d7682a655abda824c82b9d6bb7991b9576c33610/client/components/Tooltip.css#L8) to make them more readable against background text.

Here's a before / after:

![Istantanea_2019-10-09_17-50-47](https://user-images.githubusercontent.com/245615/66498189-f87a6480-eabd-11e9-8ea3-603c170d9536.png) ![Istantanea_2019-10-09_17-50-59](https://user-images.githubusercontent.com/245615/66498194-fa442800-eabd-11e9-8206-83f495e2b80b.png)
