### PR TITLE
Persisted "Show content of concatenated modules" with localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 <!-- Add changelog entries for new changes under this section -->
 
+ * **Improvement**
+   * Persist "Show content of concatenated modules" option ([#322](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/322) by [@lorenzos](https://github.com/lorenzos))
+
 ## 3.6.1
 
  * **Bug Fix**

--- a/client/components/ModulesTreemap.jsx
+++ b/client/components/ModulesTreemap.jsx
@@ -208,6 +208,11 @@ export default class ModulesTreemap extends Component {
 
   handleConcatenatedModulesContentToggle = flag => {
     store.showConcatenatedModulesContent = flag;
+    if (flag) {
+      window.localStorage.setItem('showConcatenatedModulesContent', '1');
+    } else {
+      window.localStorage.removeItem('showConcatenatedModulesContent');
+    }
   }
 
   handleChunkContextMenuHide = () => {

--- a/client/components/ModulesTreemap.jsx
+++ b/client/components/ModulesTreemap.jsx
@@ -209,7 +209,7 @@ export default class ModulesTreemap extends Component {
   handleConcatenatedModulesContentToggle = flag => {
     store.showConcatenatedModulesContent = flag;
     if (flag) {
-      localStorage.setItem('showConcatenatedModulesContent', '1');
+      localStorage.setItem('showConcatenatedModulesContent', true);
     } else {
       localStorage.removeItem('showConcatenatedModulesContent');
     }

--- a/client/components/ModulesTreemap.jsx
+++ b/client/components/ModulesTreemap.jsx
@@ -4,7 +4,7 @@ import filesize from 'filesize';
 import {computed} from 'mobx';
 import {observer} from 'mobx-preact';
 
-import {isChunkParsed} from '../utils';
+import {isChunkParsed, localStorage} from '../utils';
 import Treemap from './Treemap';
 import Tooltip from './Tooltip';
 import Switcher from './Switcher';
@@ -209,9 +209,9 @@ export default class ModulesTreemap extends Component {
   handleConcatenatedModulesContentToggle = flag => {
     store.showConcatenatedModulesContent = flag;
     if (flag) {
-      window.localStorage.setItem('showConcatenatedModulesContent', '1');
+      localStorage.setItem('showConcatenatedModulesContent', '1');
     } else {
-      window.localStorage.removeItem('showConcatenatedModulesContent');
+      localStorage.removeItem('showConcatenatedModulesContent');
     }
   }
 

--- a/client/components/ModulesTreemap.jsx
+++ b/client/components/ModulesTreemap.jsx
@@ -4,7 +4,8 @@ import filesize from 'filesize';
 import {computed} from 'mobx';
 import {observer} from 'mobx-preact';
 
-import {isChunkParsed, localStorage} from '../utils';
+import {isChunkParsed} from '../utils';
+import localStorage from '../localStorage';
 import Treemap from './Treemap';
 import Tooltip from './Tooltip';
 import Switcher from './Switcher';

--- a/client/localStorage.js
+++ b/client/localStorage.js
@@ -1,0 +1,25 @@
+const KEY_PREFIX = 'wba';
+
+export default {
+
+  getItem(key) {
+    try {
+      return JSON.parse(window.localStorage.getItem(`${KEY_PREFIX}.${key}`));
+    } catch (err) {
+      return null;
+    }
+  },
+
+  setItem(key, value) {
+    try {
+      window.localStorage.setItem(`${KEY_PREFIX}.${key}`, JSON.stringify(value));
+    } catch (err) { /* ignored */ }
+  },
+
+  removeItem(key) {
+    try {
+      window.localStorage.removeItem(`${KEY_PREFIX}.${key}`);
+    } catch (err) { /* ignored */ }
+  }
+
+};

--- a/client/store.js
+++ b/client/store.js
@@ -1,5 +1,6 @@
 import {observable, computed} from 'mobx';
-import {isChunkParsed, walkModules, localStorage} from './utils';
+import {isChunkParsed, walkModules} from './utils';
+import localStorage from './localStorage';
 
 export class Store {
   cid = 0;

--- a/client/store.js
+++ b/client/store.js
@@ -10,7 +10,7 @@ export class Store {
   @observable searchQuery = '';
   @observable defaultSize;
   @observable selectedSize;
-  @observable showConcatenatedModulesContent = localStorage.getItem('showConcatenatedModulesContent') === '1';
+  @observable showConcatenatedModulesContent = (localStorage.getItem('showConcatenatedModulesContent') === true);
 
   setModules(modules) {
     walkModules(modules, module => {

--- a/client/store.js
+++ b/client/store.js
@@ -1,5 +1,5 @@
 import {observable, computed} from 'mobx';
-import {isChunkParsed, walkModules} from './utils';
+import {isChunkParsed, walkModules, localStorage} from './utils';
 
 export class Store {
   cid = 0;
@@ -10,7 +10,7 @@ export class Store {
   @observable searchQuery = '';
   @observable defaultSize;
   @observable selectedSize;
-  @observable showConcatenatedModulesContent = window.localStorage.getItem('showConcatenatedModulesContent') === '1';
+  @observable showConcatenatedModulesContent = localStorage.getItem('showConcatenatedModulesContent') === '1';
 
   setModules(modules) {
     walkModules(modules, module => {

--- a/client/store.js
+++ b/client/store.js
@@ -10,7 +10,7 @@ export class Store {
   @observable searchQuery = '';
   @observable defaultSize;
   @observable selectedSize;
-  @observable showConcatenatedModulesContent = false;
+  @observable showConcatenatedModulesContent = window.localStorage.getItem('showConcatenatedModulesContent') === '1';
 
   setModules(modules) {
     walkModules(modules, module => {

--- a/client/utils.js
+++ b/client/utils.js
@@ -28,16 +28,16 @@ export const localStorage = {
     }
   },
 
-  setItem(k, v) {
+  setItem(key, value) {
     try {
-      window.localStorage.setItem(k, v);
-    } catch (x) { /* ignored */ }
+      window.localStorage.setItem(`${KEY_PREFIX}.${key}`, JSON.stringify(value));
+    } catch (err) { /* ignored */ }
   },
 
-  removeItem(k) {
+  removeItem(key) {
     try {
-      window.localStorage.removeItem(k);
-    } catch (x) { /* ignored */ }
+      window.localStorage.removeItem(key);
+    } catch (err) { /* ignored */ }
   }
 
 };

--- a/client/utils.js
+++ b/client/utils.js
@@ -17,27 +17,3 @@ export function walkModules(modules, cb) {
 export function elementIsOutside(elem, container) {
   return !(elem === container || container.contains(elem));
 }
-
-export const localStorage = {
-
-  getItem(k) {
-    try {
-      return window.localStorage.getItem(k);
-    } catch (x) {
-      return null;
-    }
-  },
-
-  setItem(key, value) {
-    try {
-      window.localStorage.setItem(`${KEY_PREFIX}.${key}`, JSON.stringify(value));
-    } catch (err) { /* ignored */ }
-  },
-
-  removeItem(key) {
-    try {
-      window.localStorage.removeItem(key);
-    } catch (err) { /* ignored */ }
-  }
-
-};

--- a/client/utils.js
+++ b/client/utils.js
@@ -17,3 +17,27 @@ export function walkModules(modules, cb) {
 export function elementIsOutside(elem, container) {
   return !(elem === container || container.contains(elem));
 }
+
+export const localStorage = {
+
+  getItem(k) {
+    try {
+      return window.localStorage.getItem(k);
+    } catch (x) {
+      return null;
+    }
+  },
+
+  setItem(k, v) {
+    try {
+      window.localStorage.setItem(k, v);
+    } catch (x) { /* ignored */ }
+  },
+
+  removeItem(k) {
+    try {
+      window.localStorage.removeItem(k);
+    } catch (x) { /* ignored */ }
+  }
+
+};


### PR DESCRIPTION
As discussed in #321.

To my surprise, this works also when `{ analyzerMode: 'static' }`: I didn't know browsers save `localStorage` for local files too.