### PR TITLE
fix: fix worker assets not being included in report

### DIFF
--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -36,7 +36,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
     // See #22
     asset.name = asset.name.replace(FILENAME_QUERY_REGEXP, '');
 
-    return FILENAME_EXTENSIONS.test(asset.name) && !_.isEmpty(asset.chunks) && isAssetIncluded(asset.name);
+    return FILENAME_EXTENSIONS.test(asset.name) && isAssetIncluded(asset.name);
   });
 
   // Trying to parse bundle assets and get real module sizes if `bundleDir` is provided

--- a/test/analyzer.js
+++ b/test/analyzer.js
@@ -106,6 +106,14 @@ describe('Analyzer', function () {
     generateReportFrom('with-modules-chunk.json');
     await expectValidReport({bundleLabel: 'bundle.mjs'});
   });
+
+  it('should support worker assets with empty chunks', async function () {
+    generateReportFrom('with-worker-empty-chunks.json');
+    const chartData = await getChartData();
+    expect(chartData[99]).to.containSubset({
+      label: 'blurhash.aaa4af0138af8a4c83aa.blurhash.js'
+    });
+  });
 });
 
 function generateReportFrom(statsFilename) {


### PR DESCRIPTION
Based on discussion [here](https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/150#issuecomment-548406183), this should fix #150.

I've added a `stats.json` file from my own project [Pinafore](https://github.com/nolanlawson/pinafore) in order to test. I've confirmed that the test fails without the fix but succeeds with the fix, and that no other tests are broken.

Sorry for including such a large `stats.json` file in the test, but I wasn't sure I could come up with a minimal repro.