### PR TITLE
Upgrade acorn to v7.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,9 +1172,9 @@
       }
     },
     "acorn": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -3675,6 +3675,14 @@
         "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -10636,6 +10644,12 @@
         "webpack-sources": "^1.3.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "dev": true
+        },
         "eslint-scope": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,9 +1189,9 @@
       "dev": true
     },
     "acorn-walk": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ=="
     },
     "ajv": {
       "version": "6.10.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "views"
   ],
   "dependencies": {
-    "acorn": "^6.0.7",
+    "acorn": "^7.1.1",
     "acorn-walk": "^6.1.1",
     "bfj": "^6.1.1",
     "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "acorn": "^7.1.1",
-    "acorn-walk": "^6.1.1",
+    "acorn-walk": "^7.1.1",
     "bfj": "^6.1.1",
     "chalk": "^2.4.1",
     "commander": "^2.18.0",


### PR DESCRIPTION
Upgrades acorn and acorn-walk to 7.1.1 in order to avoid the NPM audit warning here: https://www.npmjs.com/advisories/1488.

---

Tests all pass fine but I am getting these warnings from `npm` if I update `acorn` and `acorn-walk` only.

```
npm WARN acorn-dynamic-import@4.0.0 requires a peer of acorn@^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN acorn-jsx@5.0.1 requires a peer of acorn@^6.0.0 but none is installed. You must install peer dependencies yourself.
```

`acorn-jsx` is relied upon by `eslint`. `acorn-dynamic-import` is relied upon by `webpack`.

For `acorn-jsx`, I wanted to upgrade `eslint` but all this does is remove the one `npm WARN` above and replace it with three others, including one from `eslint-config-th0r` and one from `eslint-config-th0r-react` which haven't been updated in a year and rely upon `eslint` v5.x.x. It seems out of scope to change these packages upstream.

I have not yet attempted to update `webpack` but that also feels excessive here.

What is `webpack-bundle-analyzer`'s policy on having `npm WARN`s? Are they fine to have here? If not, do the maintainers have suggestions on how to work around the above warnings?