### PR TITLE
Added JSON output to the cli and webpack plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ new BundleAnalyzerPlugin(options?: object)
 
 |Name|Type|Description|
 |:--:|:--:|:----------|
-|**`analyzerMode`**|One of: `server`, `static`, `disabled`|Default: `server`. In `server` mode analyzer will start HTTP server to show bundle report. In `static` mode single HTML file with bundle report will be generated. In `disabled` mode you can use this plugin to just generate Webpack Stats JSON file by setting `generateStatsFile` to `true`. |
+|**`analyzerMode`**|One of: `server`, `static`, `json`, `disabled`|Default: `server`. In `server` mode analyzer will start HTTP server to show bundle report. In `static` mode single HTML file with bundle report will be generated. In `json` mode single JSON file with bundle report will be generated. In `disabled` mode you can use this plugin to just generate Webpack Stats JSON file by setting `generateStatsFile` to `true`. |
 |**`analyzerHost`**|`{String}`|Default: `127.0.0.1`. Host that will be used in `server` mode to start HTTP server.|
 |**`analyzerPort`**|`{Number}` or `auto`|Default: `8888`. Port that will be used in `server` mode to start HTTP server.|
 |**`reportFilename`**|`{String}`|Default: `report.html`. Path to bundle report file that will be generated in `static` mode. It can be either an absolute path or a path relative to a bundle output directory (which is output.path in webpack config).|

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -49,8 +49,8 @@ class BundleAnalyzerPlugin {
 
       if (this.opts.analyzerMode === 'server') {
         actions.push(() => this.startAnalyzerServer(stats.toJson()));
-      } else if (this.opts.analyzerMode === 'static') {
-        actions.push(() => this.generateStaticReport(stats.toJson()));
+      } else if (this.opts.analyzerMode === 'static' || this.opts.analyzerMode === 'json') {
+        actions.push(() => this.generateStaticReport(stats.toJson(), this.opts.analyzerMode));
       }
 
       if (actions.length) {
@@ -115,10 +115,11 @@ class BundleAnalyzerPlugin {
     }
   }
 
-  async generateStaticReport(stats) {
+  async generateStaticReport(stats, reportFormat) {
     await viewer.generateReport(stats, {
       openBrowser: this.opts.openAnalyzer,
       reportFilename: path.resolve(this.compiler.outputPath, this.opts.reportFilename),
+      reportFormat,
       bundleDir: this.getBundleDirFromCompiler(),
       logger: this.logger,
       defaultSizes: this.opts.defaultSizes,

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -7,12 +7,11 @@ const Logger = require('./Logger');
 const viewer = require('./viewer');
 
 class BundleAnalyzerPlugin {
-
   constructor(opts = {}) {
     this.opts = {
       analyzerMode: 'server',
       analyzerHost: '127.0.0.1',
-      reportFilename: 'report.html',
+      reportFilename,
       defaultSizes: 'parsed',
       openAnalyzer: true,
       generateStatsFile: false,
@@ -49,8 +48,10 @@ class BundleAnalyzerPlugin {
 
       if (this.opts.analyzerMode === 'server') {
         actions.push(() => this.startAnalyzerServer(stats.toJson()));
-      } else if (this.opts.analyzerMode === 'static' || this.opts.analyzerMode === 'json') {
-        actions.push(() => this.generateStaticReport(stats.toJson(), this.opts.analyzerMode));
+      } else if (this.opts.analyzerMode === 'static') {
+        actions.push(() => this.generateStaticReport(stats.toJson()));
+      } else if (this.opts.analyzerMode === 'json') {
+        actions.push(() => this.generateJSONReport(stats.toJson()));
       }
 
       if (actions.length) {
@@ -115,11 +116,19 @@ class BundleAnalyzerPlugin {
     }
   }
 
-  async generateStaticReport(stats, reportFormat) {
+  async generateJSONReport(stats) {
+    await viewer.generateJSONReport(stats, {
+      reportFilename: path.resolve(this.compiler.outputPath, this.opts.reportFilename || 'report.json'),
+      bundleDir: this.getBundleDirFromCompiler(),
+      logger: this.logger,
+      excludeAssets: this.opts.excludeAssets
+    });
+  }
+
+  async generateStaticReport(stats) {
     await viewer.generateReport(stats, {
       openBrowser: this.opts.openAnalyzer,
-      reportFilename: path.resolve(this.compiler.outputPath, this.opts.reportFilename),
-      reportFormat,
+      reportFilename: path.resolve(this.compiler.outputPath, this.opts.reportFilename || 'report.html'),
       bundleDir: this.getBundleDirFromCompiler(),
       logger: this.logger,
       defaultSizes: this.opts.defaultSizes,

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -11,7 +11,7 @@ class BundleAnalyzerPlugin {
     this.opts = {
       analyzerMode: 'server',
       analyzerHost: '127.0.0.1',
-      reportFilename,
+      reportFilename: null,
       defaultSizes: 'parsed',
       openAnalyzer: true,
       generateStatsFile: false,

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -46,8 +46,7 @@ const program = commander
   )
   .option(
     '-r, --report <file>',
-    'Path to bundle report file that will be generated in `static` mode.',
-    'report.html'
+    'Path to bundle report file that will be generated in `static` mode.'
   )
   .option(
     '-s, --default-sizes <type>',

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -28,8 +28,8 @@ const program = commander
     '-m, --mode <mode>',
     'Analyzer mode. Should be `server`,`static` or `json`.' +
       br('In `server` mode analyzer will start HTTP server to show bundle report.') +
-      br('In `static` mode single HTML file with bundle report will be generated.'),
-    br('In `json` mode single JSON file with bundle report will be generated.'),
+      br('In `static` mode single HTML file with bundle report will be generated.') +
+      br('In `json` mode single JSON file with bundle report will be generated.'),
     'server'
   )
   .option(

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -26,9 +26,10 @@ const program = commander
   )
   .option(
     '-m, --mode <mode>',
-    'Analyzer mode. Should be `server` or `static`.' +
-    br('In `server` mode analyzer will start HTTP server to show bundle report.') +
-    br('In `static` mode single HTML file with bundle report will be generated.'),
+    'Analyzer mode. Should be `server`,`static` or `json`.' +
+      br('In `server` mode analyzer will start HTTP server to show bundle report.') +
+      br('In `static` mode single HTML file with bundle report will be generated.'),
+    br('In `json` mode single JSON file with bundle report will be generated.'),
     'server'
   )
   .option(
@@ -86,7 +87,7 @@ let {
 const logger = new Logger(logLevel);
 
 if (!bundleStatsFile) showHelp('Provide path to Webpack Stats file as first argument');
-if (mode !== 'server' && mode !== 'static') showHelp('Invalid mode. Should be either `server` or `static`.');
+if (mode !== 'server' && mode !== 'static' && mode !== 'json') showHelp('Invalid mode. Should be either `server`,`static` or `json`.');
 if (mode === 'server') {
   if (!host) showHelp('Invalid host name');
 
@@ -121,7 +122,8 @@ if (mode === 'server') {
 } else {
   viewer.generateReport(bundleStats, {
     openBrowser,
-    reportFilename: resolve(reportFilename),
+    reportFormat: mode === 'static' ? 'html' : 'json',
+    reportFilename: reportFilename ? resolve(reportFilename) : null,
     defaultSizes,
     bundleDir,
     excludeAssets,

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -122,7 +122,7 @@ if (mode === 'server') {
 } else {
   viewer.generateReport(bundleStats, {
     openBrowser,
-    reportFormat: mode === 'static' ? 'html' : 'json',
+    reportFormat: mode,
     reportFilename: reportFilename ? resolve(reportFilename) : null,
     defaultSizes,
     bundleDir,

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -120,12 +120,18 @@ if (mode === 'server') {
     excludeAssets,
     logger: new Logger(logLevel)
   });
-} else {
+} else if (mode === 'static') {
   viewer.generateReport(bundleStats, {
     openBrowser,
-    reportFormat: mode,
-    reportFilename: reportFilename ? resolve(reportFilename) : null,
+    reportFilename: resolve(reportFilename || 'report.html'),
     defaultSizes,
+    bundleDir,
+    excludeAssets,
+    logger: new Logger(logLevel)
+  });
+} else if (mode === 'json') {
+  viewer.generateJSONReport(bundleStats, {
+    reportFilename: resolve(reportFilename || 'report.json'),
     bundleDir,
     excludeAssets,
     logger: new Logger(logLevel)

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -87,7 +87,9 @@ let {
 const logger = new Logger(logLevel);
 
 if (!bundleStatsFile) showHelp('Provide path to Webpack Stats file as first argument');
-if (mode !== 'server' && mode !== 'static' && mode !== 'json') showHelp('Invalid mode. Should be either `server`,`static` or `json`.');
+if (mode !== 'server' && mode !== 'static' && mode !== 'json') {
+  showHelp('Invalid mode. Should be either `server`,`static` or `json`.');
+}
 if (mode === 'server') {
   if (!host) showHelp('Invalid host name');
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -133,14 +133,15 @@ async function generateReport(bundleStats, opts) {
 
   if (!chartData) return;
 
-  function saveReport(content) {
-    const reportFilenameWithExtension = reportFilename
-      ? reportFilename
-      : reportFormat === 'static'
-        ? 'report.html'
-        : 'report.json';
+  const reportFilenameWithExtension = reportFilename
+    ? reportFilename
+    : reportFormat === 'static'
+      ? 'report.html'
+      : 'report.json';
 
-    const reportFilepath = path.resolve(reportFilenameWithExtension);
+  const reportFilepath = path.resolve(reportFilenameWithExtension);
+
+  function saveReport(content) {
     mkdir.sync(path.dirname(reportFilepath));
     fs.writeFileSync(reportFilepath, content);
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -183,7 +183,7 @@ async function generateJSONReport(bundleStats, opts) {
   mkdir.sync(path.dirname(reportFilename));
   fs.writeFileSync(reportFilename, JSON.stringify(chartData));
 
-  logger.info(`${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilename)}`);
+  logger.info(`${bold('Webpack Bundle Analyzer')} saved JSON report to ${bold(reportFilename)}`);
 }
 
 function getAssetContent(filename) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -133,8 +133,6 @@ async function generateReport(bundleStats, opts) {
 
   if (!chartData) return;
 
-  const reportFilepath = path.resolve(reportFilename);
-
   await new Promise((resolve, reject) => {
     ejs.renderFile(
       `${projectRoot}/views/viewer.ejs`,
@@ -156,13 +154,13 @@ async function generateReport(bundleStats, opts) {
             return;
           }
 
-          mkdir.sync(path.dirname(reportFilepath));
-          fs.writeFileSync(reportFilepath, reportHtml);
+          mkdir.sync(path.dirname(reportFilename));
+          fs.writeFileSync(reportFilename, reportHtml);
 
-          logger.info(`${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilepath)}`);
+          logger.info(`${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilename)}`);
 
           if (openBrowser) {
-            opener(`file://${reportFilepath}`);
+            opener(`file://${reportFilename}`);
           }
           resolve();
         } catch (e) {
@@ -180,12 +178,10 @@ async function generateJSONReport(bundleStats, opts) {
 
   if (!chartData) return;
 
-  const reportFilepath = path.resolve(reportFilename);
+  mkdir.sync(path.dirname(reportFilename));
+  fs.writeFileSync(reportFilename, JSON.stringify(chartData));
 
-  mkdir.sync(path.dirname(reportFilepath));
-  fs.writeFileSync(reportFilepath, JSON.stringify(chartData));
-
-  logger.info(`${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilepath)}`);
+  logger.info(`${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilename)}`);
 }
 
 function getAssetContent(filename) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -154,13 +154,15 @@ async function generateReport(bundleStats, opts) {
             return;
           }
 
-          mkdir.sync(path.dirname(reportFilename));
-          fs.writeFileSync(reportFilename, reportHtml);
+          const reportFilepath = path.resolve(bundleDir || process.cwd(), reportFilename);
 
-          logger.info(`${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilename)}`);
+          mkdir.sync(path.dirname(reportFilepath));
+          fs.writeFileSync(reportFilepath, reportHtml);
+
+          logger.info(`${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilepath)}`);
 
           if (openBrowser) {
-            opener(`file://${reportFilename}`);
+            opener(`file://${reportFilepath}`);
           }
           resolve();
         } catch (e) {

--- a/test/analyzer.js
+++ b/test/analyzer.js
@@ -109,17 +109,21 @@ describe('Analyzer', function () {
   });
 
   it('should support generating JSON output for the report', async function () {
-    const reportPath = 'output/report.json';
+    generateJSONReportFrom('with-modules-in-chunks/stats.json');
 
-    generateReportFrom('with-modules-in-chunks/stats.json', {format: 'json', outputFilename: reportPath});
-
-    const chartData = require(path.resolve(__dirname, reportPath));
+    const chartData = require(path.resolve(__dirname, 'output/report.json'));
     expect(chartData).to.containSubset(require('./stats/with-modules-in-chunks/expected-chart-data'));
   });
 });
 
-function generateReportFrom(statsFilename, {format = 'static', outputFilename = 'output/report.html'} = {}) {
-  childProcess.execSync(`../lib/bin/analyzer.js -m ${format} -r ${outputFilename} -O stats/${statsFilename}`, {
+function generateJSONReportFrom(statsFilename) {
+  childProcess.execSync(`../lib/bin/analyzer.js -m json -r output/report.json stats/${statsFilename}`, {
+    cwd: __dirname
+  });
+}
+
+function generateReportFrom(statsFilename) {
+  childProcess.execSync(`../lib/bin/analyzer.js -m static -r output/report.html -O stats/${statsFilename}`, {
     cwd: __dirname
   });
 }

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -63,7 +63,10 @@ describe('Plugin', function () {
   it('should support webpack config with `multi` module', async function () {
     const config = makeWebpackConfig();
 
-    config.entry.bundle = ['./src/a.js', './src/b.js'];
+    config.entry.bundle = [
+      './src/a.js',
+      './src/b.js'
+    ];
 
     await webpackCompile(config);
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const del = require('del');
 const _ = require('lodash');
-
+const path = require('path');
 const BundleAnalyzerPlugin = require('../lib/BundleAnalyzerPlugin');
 
 describe('Plugin', function () {
@@ -47,22 +47,34 @@ describe('Plugin', function () {
     });
   });
 
+  it('should allow to generate json report', async function () {
+    const config = makeWebpackConfig({
+      analyzerOpts: {
+        analyzerMode: 'json'
+      }
+    });
+
+    await webpackCompile(config);
+
+    const chartData = await getChartDataFromJSONReport();
+    expect(chartData).to.exist;
+  });
+
   it('should support webpack config with `multi` module', async function () {
     const config = makeWebpackConfig();
 
-    config.entry.bundle = [
-      './src/a.js',
-      './src/b.js'
-    ];
+    config.entry.bundle = ['./src/a.js', './src/b.js'];
 
     await webpackCompile(config);
 
     const chartData = await getChartDataFromReport();
-    expect(chartData[0].groups).to.containSubset([{
-      label: 'multi ./src/a.js ./src/b.js',
-      path: './multi ./src/a.js ./src/b.js',
-      groups: undefined
-    }]);
+    expect(chartData[0].groups).to.containSubset([
+      {
+        label: 'multi ./src/a.js ./src/b.js',
+        path: './multi ./src/a.js ./src/b.js',
+        groups: undefined
+      }
+    ]);
   });
 
   describe('options', function () {
@@ -104,9 +116,11 @@ describe('Plugin', function () {
     });
   }
 
+  function getChartDataFromJSONReport(reportFilename = 'report.json') {
+    return require(path.resolve(__dirname, `output/${reportFilename}`));
+  }
+
   async function getChartDataFromReport(reportFilename = 'report.html') {
-    return await nightmare
-      .goto(`file://${__dirname}/output/${reportFilename}`)
-      .evaluate(() => window.chartData);
+    return await nightmare.goto(`file://${__dirname}/output/${reportFilename}`).evaluate(() => window.chartData);
   }
 });


### PR DESCRIPTION
## Issue
This issue can be related to https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/194.

We would like to use the statistics generated by Webpack Bundle Analyzer to track changes in projects. For that we would like to upload/save the bundle sizes in a database, and json is a lot more flexible format for that. 

## Tests

I've added a test for the json output.

## Next step

There is already possibility to generate html from the given json (you expose ejs file that we can directly use). But I think it would be great to add a way to generate the html from cli, but I can't think of a nice way to do it. This is what I currently have created: https://github.com/Gongreg/webpack-bundle-analyzer/pull/1/files 