### PR TITLE
add support for node bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /samples
 node_modules
 npm-debug.log
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 <!-- Add changelog entries for new changes under this section -->
 
+## 3.7.1
+
+ * **Improvement**
+   * Added support for exports.modules when webpack target = node
+
 ## 3.7.0
 
  * **New Feature**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-analyzer",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Webpack plugin and CLI utility that represents bundle content as convenient interactive zoomable treemap",
   "author": "Yury Grunin <grunin.ya@ya.ru>",
   "license": "MIT",

--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -25,6 +25,21 @@ function parseBundle(bundlePath) {
     ast,
     walkState,
     {
+      AssignmentExpression(node, state,) {
+        if (state.locations) return;
+
+        // Modules are stored in exports.modules:
+        // exports.modules = {};
+        const {left, right} = node;
+
+        if (
+          left &&
+          left.object && left.object.name === 'exports' &&
+          left.property && left.property.name === 'modules'
+        ) {
+          state.locations = getModulesLocations(right);
+        }
+      },
       CallExpression(node, state, c) {
         if (state.locations) return;
 

--- a/test/bundles/validNodeBundleWithModulesAsArray.js
+++ b/test/bundles/validNodeBundleWithModulesAsArray.js
@@ -1,0 +1,6 @@
+exports.ids = ["common"];
+exports.modules = {
+  0: function(e,t,n){n(1),n(21),n(96),n(306),n(23),n(150),n(57),n(56),n(34),n(138),e.exports=n(348)},
+  3: function(e,t,n){"use strict";e.exports=n(680)},
+  5: function(e,t){}
+};

--- a/test/bundles/validNodeBundleWithModulesAsArray.modules.json
+++ b/test/bundles/validNodeBundleWithModulesAsArray.modules.json
@@ -1,0 +1,7 @@
+{
+  "modules": {
+    "0": "function(e,t,n){n(1),n(21),n(96),n(306),n(23),n(150),n(57),n(56),n(34),n(138),e.exports=n(348)}",
+    "3": "function(e,t,n){\"use strict\";e.exports=n(680)}",
+    "5": "function(e,t){}"
+  }
+}


### PR DESCRIPTION
when webpack config target=node, the modules are store at exports.modules. 