### PR TITLE
feat: Render Selected Module Size Total 

### DIFF
--- a/client/components/ModulesTreemap.jsx
+++ b/client/components/ModulesTreemap.jsx
@@ -115,6 +115,11 @@ export default class ModulesTreemap extends Component {
                 onChange={this.handleSelectedChunksChange}/>
             </div>
           }
+          {this.isTotalSelectedSizeVisible() &&
+            <div className={s.sidebarGroup}>
+              {this.renderSelectedChunkSize()}
+            </div>
+          }
         </Sidebar>
         <Treemap ref={this.saveTreemapRef}
           className={s.map}
@@ -161,6 +166,13 @@ export default class ModulesTreemap extends Component {
       ')'
     ];
   };
+
+  renderSelectedChunkSize = () => {
+    const {activeSize, selectedChunks} = this.store;
+    const totalSize = selectedChunks.reduce((memo, item) => (item[activeSize] + memo), 0);
+
+    return <div>Total selected size: <strong>{filesize(totalSize)}</strong></div>;
+  }
 
   @computed get sizeSwitchItems() {
     return store.hasParsedSizes ? SIZE_SWITCH_ITEMS : SIZE_SWITCH_ITEMS.slice(0, 1);
@@ -304,6 +316,10 @@ export default class ModulesTreemap extends Component {
 
   isModuleVisible = module => (
     this.treemap.isGroupRendered(module)
+  )
+
+  isTotalSelectedSizeVisible = () => (
+    store.selectedChunks.length > 1 && store.selectedChunks.length < this.chunkItems.length
   )
 
   saveTreemapRef = treemap => this.treemap = treemap;


### PR DESCRIPTION
Small UI update to render a label of the total selected module size in the sidebar. If the user has all the modules selected, or only one, it will not display as that information is easily accessible.

![Image 4-28-20 at 6 31 PM](https://user-images.githubusercontent.com/5093459/80553403-99f3d580-897e-11ea-96b6-d2c7b121be85.jpeg)

Have found myself needing this more often than not to compare the sizes of subsets of bundles.

Wasn't able to find any tests on UI components. If I'm simply blind, please point me in the right direction and I'm happy to add some coverage. 

Thanks!