### PR TITLE
feat: allows deterministic reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 <!-- Add changelog entries for new changes under this section -->
 
+ * **New Feature**
+   * Added deterministic option (`deterministic: true` in plugin, `--deterministic` in CLI) (https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/347) by [@eoingroat](https://github.com/eoingroat)
+
 ## 3.7.0
 
  * **New Feature**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 <!-- Add changelog entries for new changes under this section -->
 
  * **New Feature**
-   * Added deterministic option (`deterministic: true` in plugin, `--deterministic` in CLI) (https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/347) by [@eoingroat](https://github.com/eoingroat)
+   * Added deterministic option (`deterministic: true` in plugin, `--deterministic` in CLI) (https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/348) by [@eoingroat](https://github.com/eoingroat)
 
 ## 3.7.0
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ new BundleAnalyzerPlugin(options?: object)
 |**`statsFilename`**|`{String}`|Default: `stats.json`. Name of webpack stats JSON file that will be generated if `generateStatsFile` is `true`. It can be either an absolute path or a path relative to a bundle output directory (which is output.path in webpack config).|
 |**`statsOptions`**|`null` or `{Object}`|Default: `null`. Options for `stats.toJson()` method. For example you can exclude sources of your modules from stats file with `source: false` option. [See more options here](https://webpack.js.org/configuration/stats/). |
 |**`excludeAssets`**|`{null\|pattern\|pattern[]}` where `pattern` equals to `{String\|RegExp\|function}`|Default: `null`. Patterns that will be used to match against asset names to exclude them from the report. If pattern is a string it will be converted to RegExp via `new RegExp(str)`. If pattern is a function it should have the following signature `(assetName: string) => boolean` and should return `true` to *exclude* matching asset. If multiple patterns are provided asset should match at least one of them to be excluded. |
+|**`deterministic`**|`{Boolean}`|Default: `false`. Controls whether the output includes non-deterministic factors, such as the time the report was generated.|
 |**`logLevel`**|One of: `info`, `warn`, `error`, `silent`|Default: `info`. Used to control how much details the plugin outputs.|
 
 <h2 align="center">Usage (as a CLI utility)</h2>
@@ -123,6 +124,8 @@ Directory containing all generated bundles.
   -O, --no-open               Don't open report in default browser automatically.
   -e, --exclude <regexp>      Assets that should be excluded from the report.
                               Can be specified multiple times.
+  -d, --deterministic         Controls whether the output includes non-deterministic
+                              factors, such as the time the report was generated.
   -l, --log-level <level>     Log level.
                               Possible values: debug, info, warn, error, silent (default: info)
   -h, --help                  output usage information

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -19,6 +19,7 @@ class BundleAnalyzerPlugin {
       statsOptions: null,
       excludeAssets: null,
       logLevel: 'info',
+      deterministic: false,
       // deprecated
       startAnalyzer: true,
       ...opts,
@@ -109,6 +110,7 @@ class BundleAnalyzerPlugin {
         host: this.opts.analyzerHost,
         port: this.opts.analyzerPort,
         bundleDir: this.getBundleDirFromCompiler(),
+        deterministic: this.opts.deterministic,
         logger: this.logger,
         defaultSizes: this.opts.defaultSizes,
         excludeAssets: this.opts.excludeAssets
@@ -131,6 +133,7 @@ class BundleAnalyzerPlugin {
       reportFilename: path.resolve(this.compiler.outputPath, this.opts.reportFilename || 'report.html'),
       bundleDir: this.getBundleDirFromCompiler(),
       logger: this.logger,
+      deterministic: this.opts.deterministic,
       defaultSizes: this.opts.defaultSizes,
       excludeAssets: this.opts.excludeAssets
     });

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -65,6 +65,12 @@ const program = commander
     array()
   )
   .option(
+    '-d, --deterministic',
+    'Controls whether the output includes non-deterministic' +
+    br('factors, such as the time the report was generated.'),
+    false
+  )
+  .option(
     '-l, --log-level <level>',
     'Log level.' +
     br(`Possible values: ${[...Logger.levels].join(', ')}`),
@@ -78,6 +84,7 @@ let {
   port,
   report: reportFilename,
   defaultSizes,
+  deterministic,
   logLevel,
   open: openBrowser,
   exclude: excludeAssets,
@@ -115,6 +122,7 @@ if (mode === 'server') {
     openBrowser,
     port,
     host,
+    deterministic,
     defaultSizes,
     bundleDir,
     excludeAssets,
@@ -124,6 +132,7 @@ if (mode === 'server') {
   viewer.generateReport(bundleStats, {
     openBrowser,
     reportFilename: resolve(reportFilename || 'report.html'),
+    deterministic,
     defaultSizes,
     bundleDir,
     excludeAssets,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -25,7 +25,17 @@ module.exports = {
   start: startServer
 };
 
-const title = `${process.env.npm_package_name || 'Webpack Bundle Analyzer'} [${utils.getCurrentTime()}]`;
+function getTitle(opts) {
+  const {
+    deterministic = false
+  } = opts || {};
+
+  if (deterministic) {
+    return `${process.env.npm_package_name || 'Webpack Bundle Analyzer'}`;
+  } else {
+    return `${process.env.npm_package_name || 'Webpack Bundle Analyzer'} [${utils.getCurrentTime()}]`;
+  }
+}
 
 async function startServer(bundleStats, opts) {
   const {
@@ -34,6 +44,7 @@ async function startServer(bundleStats, opts) {
     openBrowser = true,
     bundleDir = null,
     logger = new Logger(),
+    deterministic = false,
     defaultSizes = 'parsed',
     excludeAssets = null
   } = opts || {};
@@ -56,7 +67,9 @@ async function startServer(bundleStats, opts) {
   app.use('/', (req, res) => {
     res.render('viewer', {
       mode: 'server',
-      title,
+      title: getTitle({
+        deterministic
+      }),
       get chartData() { return chartData },
       defaultSizes,
       enableWebSocket: true,
@@ -125,6 +138,7 @@ async function generateReport(bundleStats, opts) {
     reportFilename,
     bundleDir = null,
     logger = new Logger(),
+    deterministic = false,
     defaultSizes = 'parsed',
     excludeAssets = null
   } = opts || {};
@@ -138,7 +152,9 @@ async function generateReport(bundleStats, opts) {
       `${projectRoot}/views/viewer.ejs`,
       {
         mode: 'static',
-        title,
+        title: getTitle({
+          deterministic
+        }),
         chartData,
         defaultSizes,
         enableWebSocket: false,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,6 +7,7 @@ chai.use(require('chai-subset'));
 global.expect = chai.expect;
 global.webpackCompile = webpackCompile;
 global.makeWebpackConfig = makeWebpackConfig;
+global.withMockedDate = withMockedDate;
 
 const BundleAnalyzerPlugin = require('../lib/BundleAnalyzerPlugin');
 
@@ -80,3 +81,21 @@ function makeWebpackConfig(opts) {
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+const realDate = global.Date;
+
+async function withMockedDate(targetDate, func) {
+  global.Date = function() {
+    return targetDate;
+  }
+  global.Date.now = realDate.now;
+  try {
+    return await func()
+  } catch(e) {
+    throw e;
+  } finally {
+    global.Date = realDate;
+  }
+}
+const date2017 = new Date(1500000000000);
+const date2018 = new Date(1520000000000);

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -81,6 +81,51 @@ describe('Plugin', function () {
   });
 
   describe('options', function () {
+    describe('deterministic', function () {
+      it('should support deterministic builds', async function () {
+        const config = makeWebpackConfig({
+          analyzerOpts: {
+            deterministic: true
+          }
+        });
+
+        const firstReport = await withMockedDate(date2017, async () => {
+          await webpackCompile(config);
+          const file = await fs.promises.readFile(path.resolve(__dirname, `output/report.html`));
+          return file.toString();
+        });
+
+        const secondReport = await withMockedDate(date2018, async () => {
+          await webpackCompile(config);
+          const file = await fs.promises.readFile(path.resolve(__dirname, `output/report.html`));
+          return file.toString();
+        });
+
+        expect(firstReport).to.equal(secondReport);
+      })
+      it('should support non-deterministic builds', async function () {
+        const config = makeWebpackConfig({
+          analyzerOpts: {
+            deterministic: false
+          }
+        });
+        
+        const firstReport = await withMockedDate(date2017, async () => {
+          await webpackCompile(config);
+          const file = await fs.promises.readFile(path.resolve(__dirname, `output/report.html`));
+          return file.toString();
+        });
+
+        const secondReport = await withMockedDate(date2018, async () => {
+          await webpackCompile(config);
+          const file = await fs.promises.readFile(path.resolve(__dirname, `output/report.html`));
+          return file.toString();
+        });
+
+        expect(firstReport).not.to.equal(secondReport);
+      })
+    })
+
     describe('excludeAssets', function () {
       it('should filter out assets from the report', async function () {
         const config = makeWebpackConfig({


### PR DESCRIPTION
Allows building reports deterministically; a la [Deterministic Compilation / Reproducible Builds](https://en.wikipedia.org/wiki/Reproducible_builds)

For now, that consists of adding an option to remove the report generation time from the report title; making the report generation reproducible across time.

## tests

Tests are included, they check builds are deterministic with the deterministic API option true, and non-deterministic with the option false.

## why

I've adopted a zero-config (a la yarn 2) and fully reproducible artifact build and test strategy; which means I need to commit my reports into a form of version control.

## thoughts

I was going to propose this as a default to deterministic, however it may be the case that users use the included timestamp to determine the recency of the report when developing, and thus defaulted to the existing behavior.