### PR TITLE
chore: do not throw if an invalid log-level is passed

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -25,8 +25,6 @@ class Logger {
   setLogLevel(level) {
     const levelIndex = LEVELS.indexOf(level);
 
-    if (levelIndex === -1) throw new Error(`Invalid log level "${level}". Use one of these: ${LEVELS.join(', ')}`);
-
     this.activeLevels.clear();
 
     for (const [i, level] of LEVELS.entries()) {

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -19,7 +19,7 @@ const program = commander
 `<bundleStatsFile> [bundleDir] [options]
 
   Arguments:
-  
+
     bundleStatsFile  Path to Webpack Stats JSON file.
     bundleDir        Directory containing all generated bundles.
                      You should provided it if you want analyzer to show you the real parsed module sizes.
@@ -105,7 +105,13 @@ if (mode === 'server') {
   port = port === 'auto' ? 0 : Number(port);
   if (isNaN(port)) showHelp('Invalid port. Should be a number or `auto`');
 }
-if (!SIZES.has(defaultSizes)) showHelp(`Invalid default sizes option. Possible values are: ${[...SIZES].join(', ')}`);
+if (!SIZES.has(defaultSizes)) {
+  showHelp(`Invalid default sizes option. Possible values are: ${[...SIZES].join(', ')}`);
+}
+
+if (!Logger.levels.includes(logLevel)) {
+  showHelp(`Invalid log level. Possible values are: ${[...Logger.levels].join(', ')}`);
+}
 
 bundleStatsFile = resolve(bundleStatsFile);
 

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -110,7 +110,7 @@ if (!SIZES.has(defaultSizes)) {
 }
 
 if (!Logger.levels.includes(logLevel)) {
-  showHelp(`Invalid log level. Possible values are: ${[...Logger.levels].join(', ')}`);
+  showHelp(`Invalid log level "${logLevel}". Use one of these: ${[...Logger.levels].join(', ')}`);
 }
 
 bundleStatsFile = resolve(bundleStatsFile);

--- a/test/Logger.js
+++ b/test/Logger.js
@@ -55,12 +55,12 @@ describe('Logger', function () {
       expectLoggerLevel(logger, 'silent');
     });
 
-    it('should throw if level is invalid on instance creation', function () {
-      expect(() => new TestLogger('invalid')).to.throw(invalidLogLevelMessage('invalid'));
+    it('should not throw if level is invalid on instance creation', function () {
+      expect(() => new TestLogger('invalid')).not.to.throw(invalidLogLevelMessage('invalid'));
     });
 
-    it('should throw if level is invalid on `setLogLevel`', function () {
-      expect(() => new TestLogger().setLogLevel('invalid')).to.throw(invalidLogLevelMessage('invalid'));
+    it('should not throw if level is invalid on `setLogLevel`', function () {
+      expect(() => new TestLogger().setLogLevel('invalid')).not.to.throw(invalidLogLevelMessage('invalid'));
     });
   });
 });


### PR DESCRIPTION
A suitable message shows up along with the `help information` just as we have for `--default-sizes` flag.