### PR TITLE
update readme with npm shorter commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ```bash
 # NPM
-npm install --save-dev webpack-bundle-analyzer
+npm i -D webpack-bundle-analyzer
 # Yarn
 yarn add -D webpack-bundle-analyzer
 ```


### PR DESCRIPTION
no one types `npm install --save-dev...` but rather `npm i -D...`