### PR TITLE
Replace `bfj` module with custom `stats.json` writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 <!-- Add changelog entries for new changes under this section -->
 
+ * **Improvement**
+   * Significantly speed up generation of `stats.json` file (see `generateStatsFile` option).
+
 ## 4.0.0
 
  * **Breaking change**

--- a/package-lock.json
+++ b/package-lock.json
@@ -2219,17 +2219,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bfj": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
-      "integrity": "sha512-+e/UqUzwmzJamNF50tBV6tZPTORow7gQ96iFow+8b562OdMpEK0BcJEq2OSPEDmAbSMBQ7PKZ87ubFkgxpYWgw==",
-      "requires": {
-        "bluebird": "^3.5.5",
-        "check-types": "^11.1.1",
-        "hoopy": "^0.1.4",
-        "tryer": "^1.0.1"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -2251,11 +2240,6 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -2514,11 +2498,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
-    },
-    "check-types": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
-      "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
     },
     "chokidar": {
       "version": "2.1.8",
@@ -5748,11 +5727,6 @@
       "requires": {
         "parse-passwd": "^1.0.0"
       }
-    },
-    "hoopy": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -13610,11 +13584,6 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
-    },
-    "tryer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
     "tslib": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "acorn": "^8.0.4",
     "acorn-walk": "^8.0.0",
-    "bfj": "^7.0.2",
     "chalk": "^4.1.0",
     "commander": "^6.2.0",
     "ejs": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-config-th0r-react": "2.0.1",
     "eslint-plugin-react": "7.21.5",
     "exports-loader": "1.1.1",
+    "globby": "11.0.1",
     "gulp": "4.0.2",
     "gulp-babel": "8.0.0",
     "mobx": "5.15.7",

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -1,4 +1,3 @@
-const bfj = require('bfj');
 const path = require('path');
 const mkdir = require('mkdirp');
 const {bold} = require('chalk');
@@ -6,6 +5,7 @@ const {bold} = require('chalk');
 const Logger = require('./Logger');
 const viewer = require('./viewer');
 const utils = require('./utils');
+const {writeStats} = require('./statsUtils');
 
 class BundleAnalyzerPlugin {
   constructor(opts = {}) {
@@ -83,14 +83,7 @@ class BundleAnalyzerPlugin {
     mkdir.sync(path.dirname(statsFilepath));
 
     try {
-      await bfj.write(statsFilepath, stats, {
-        space: 2,
-        promises: 'ignore',
-        buffers: 'ignore',
-        maps: 'ignore',
-        iterables: 'ignore',
-        circular: 'ignore'
-      });
+      await writeStats(stats, statsFilepath);
 
       this.logger.info(
         `${bold('Webpack Bundle Analyzer')} saved stats file to ${bold(statsFilepath)}`

--- a/src/statsUtils.js
+++ b/src/statsUtils.js
@@ -32,7 +32,7 @@ class StatsSerializeStream extends Readable {
   * _stringify(obj) {
     if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || obj === null) {
       yield JSON.stringify(obj);
-    } else if (_.isArray(obj)) {
+    } else if (Array.isArray(obj)) {
       yield '[';
       this._indentLevel++;
 

--- a/src/statsUtils.js
+++ b/src/statsUtils.js
@@ -1,8 +1,6 @@
 const {createWriteStream} = require('fs');
 const {Readable} = require('stream');
 
-const _ = require('lodash');
-
 class StatsSerializeStream extends Readable {
   constructor(stats) {
     super();
@@ -49,7 +47,7 @@ class StatsSerializeStream extends Readable {
 
       this._indentLevel--;
       yield obj.length ? `\n${this._indent}]` : ']';
-    } else if (_.isPlainObject(obj)) {
+    } else {
       yield '{';
       this._indentLevel++;
 

--- a/src/statsUtils.js
+++ b/src/statsUtils.js
@@ -1,0 +1,84 @@
+const {createWriteStream} = require('fs');
+const {Readable} = require('stream');
+
+const _ = require('lodash');
+
+class StatsSerializeStream extends Readable {
+  constructor(stats) {
+    super();
+    this._indentLevel = 0;
+    this._stringifier = this._stringify(stats);
+  }
+
+  get _indent() {
+    return '  '.repeat(this._indentLevel);
+  }
+
+  _read() {
+    let readMore = true;
+
+    while (readMore) {
+      const {value, done} = this._stringifier.next();
+
+      if (done) {
+        this.push(null);
+        readMore = false;
+      } else {
+        readMore = this.push(value);
+      }
+    }
+  }
+
+  * _stringify(obj) {
+    if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || obj === null) {
+      yield JSON.stringify(obj);
+    } else if (_.isArray(obj)) {
+      yield '[';
+      this._indentLevel++;
+
+      let isFirst = true;
+      for (let item of obj) {
+        if (item === undefined) {
+          item = null;
+        }
+
+        yield `${isFirst ? '' : ','}\n${this._indent}`;
+        yield* this._stringify(item);
+        isFirst = false;
+      }
+
+      this._indentLevel--;
+      yield obj.length ? `\n${this._indent}]` : ']';
+    } else if (_.isPlainObject(obj)) {
+      yield '{';
+      this._indentLevel++;
+
+      let isFirst = true;
+      const entries = Object.entries(obj);
+      for (const [itemKey, itemValue] of entries) {
+        if (itemValue === undefined) {
+          continue;
+        }
+
+        yield `${isFirst ? '' : ','}\n${this._indent}${JSON.stringify(itemKey)}: `;
+        yield* this._stringify(itemValue);
+        isFirst = false;
+      }
+
+      this._indentLevel--;
+      yield entries.length ? `\n${this._indent}}` : '}';
+    }
+  }
+}
+
+exports.StatsSerializeStream = StatsSerializeStream;
+exports.writeStats = writeStats;
+
+async function writeStats(stats, filepath) {
+  return new Promise((resolve, reject) => {
+    new StatsSerializeStream(stats)
+      .on('end', resolve)
+      .on('error', reject)
+      .pipe(createWriteStream(filepath));
+  });
+}

--- a/test/statsUtils.js
+++ b/test/statsUtils.js
@@ -1,0 +1,63 @@
+const {StatsSerializeStream} = require('../lib/statsUtils');
+
+describe('StatsSerializeStream', () => {
+  it('should properly stringify a primitives', function () {
+    expectProperJson(0);
+    expectProperJson(1);
+    expectProperJson(-1);
+    expectProperJson(42.42);
+    expectProperJson(-42.42);
+    expectProperJson(false);
+    expectProperJson(true);
+    expectProperJson(null);
+    expectProperJson(null);
+    expectProperJson('');
+    expectProperJson('"');
+    expectProperJson('foo bar');
+    expectProperJson('"foo bar"');
+    expectProperJson('Вива Лас-Вегас!');
+  });
+
+  it('should properly stringify simple arrays', function () {
+    expectProperJson([]);
+    expectProperJson([1, undefined, 2]);
+    expectProperJson([1, , 2]);
+    expectProperJson([false, 'f\'o"o', -1, 42.42]);
+  });
+
+  it('should properly stringify objects', function () {
+    expectProperJson({});
+    expectProperJson({a: 1, 'foo-bar': null, undef: undefined, '"Гусь!"': true});
+  });
+
+  it('should properly stringify complex objects', function () {
+    expectProperJson({
+      foo: [],
+      bar: {
+        baz: [
+          1,
+          {a: 1, b: ['foo', 'bar'], c: []},
+          'foo',
+          {a: 1, b: undefined, c: [{d: true}]},
+          null,
+          undefined
+        ]
+      }
+    });
+  });
+});
+
+async function expectProperJson(json) {
+  expect(await stringify(json)).to.equal(JSON.stringify(json, null, 2));
+}
+
+async function stringify(json) {
+  return new Promise((resolve, reject) => {
+    let result = '';
+
+    new StatsSerializeStream(json)
+      .on('data', chunk => result += chunk)
+      .on('end', () => resolve(result))
+      .on('error', reject);
+  });
+}

--- a/test/statsUtils.js
+++ b/test/statsUtils.js
@@ -21,6 +21,7 @@ describe('StatsSerializeStream', () => {
   it('should properly stringify simple arrays', function () {
     expectProperJson([]);
     expectProperJson([1, undefined, 2]);
+    // eslint-disable-next-line
     expectProperJson([1, , 2]);
     expectProperJson([false, 'f\'o"o', -1, 42.42]);
   });

--- a/test/statsUtils.js
+++ b/test/statsUtils.js
@@ -1,3 +1,7 @@
+const path = require('path');
+const {readFileSync} = require('fs');
+const globby = require('globby');
+
 const {StatsSerializeStream} = require('../lib/statsUtils');
 
 describe('StatsSerializeStream', () => {
@@ -44,6 +48,14 @@ describe('StatsSerializeStream', () => {
           undefined
         ]
       }
+    });
+  });
+
+  globby.sync('stats/**/*.json', {cwd: __dirname}).forEach(filepath => {
+    it(`should properly stringify JSON from "${filepath}"`, function () {
+      const content = readFileSync(path.resolve(__dirname, filepath), 'utf8');
+      const json = JSON.parse(content);
+      expectProperJson(json);
     });
   });
 });

--- a/test/statsUtils.js
+++ b/test/statsUtils.js
@@ -1,7 +1,7 @@
 const {StatsSerializeStream} = require('../lib/statsUtils');
 
 describe('StatsSerializeStream', () => {
-  it('should properly stringify a primitives', function () {
+  it('should properly stringify primitives', function () {
     expectProperJson(0);
     expectProperJson(1);
     expectProperJson(-1);
@@ -30,7 +30,7 @@ describe('StatsSerializeStream', () => {
     expectProperJson({a: 1, 'foo-bar': null, undef: undefined, '"Гусь!"': true});
   });
 
-  it('should properly stringify complex objects', function () {
+  it('should properly stringify complex structures', function () {
     expectProperJson({
       foo: [],
       bar: {


### PR DESCRIPTION
This PR replaces `bfj` module with custom `StatsSerializeStream` class which writes `stats.json` significantly faster (by about 6 times). Tested on 195mb `stats.json` file.