### PR TITLE
Drop lodash from the package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3036,6 +3036,23 @@
       "requires": {
         "each-props": "^1.3.0",
         "is-plain-object": "^2.0.1"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "core-js": {
@@ -4005,6 +4022,23 @@
       "requires": {
         "is-plain-object": "^2.0.1",
         "object.defaults": "^1.1.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "ecc-jsbn": {
@@ -4731,7 +4765,24 @@
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
+          },
+          "dependencies": {
+            "is-plain-object": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+              "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+              "dev": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              }
+            }
           }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -5126,6 +5177,23 @@
         "object.defaults": "^1.1.0",
         "object.pick": "^1.2.0",
         "parse-filepath": "^1.0.1"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "flagged-respawn": {
@@ -6388,21 +6456,9 @@
       "dev": true
     },
     "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
-      "requires": {
-        "isobject": "^3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-regex": {
       "version": "1.1.1",
@@ -6802,6 +6858,23 @@
         "object.map": "^1.0.0",
         "rechoir": "^0.6.2",
         "resolve": "^1.1.7"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "line-column": {
@@ -6891,7 +6964,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -7275,7 +7349,24 @@
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
+          },
+          "dependencies": {
+            "is-plain-object": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+              "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+              "dev": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              }
+            }
           }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -12330,6 +12421,21 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "express": "^4.17.1",
     "filesize": "^6.1.0",
     "gzip-size": "^6.0.0",
-    "lodash": "^4.17.20",
+    "is-plain-object": "^5.0.0",
     "opener": "^1.5.2",
     "ws": "^7.3.1"
   },
@@ -74,6 +74,7 @@
     "globby": "11.0.1",
     "gulp": "4.0.2",
     "gulp-babel": "8.0.0",
+    "lodash": "^4.17.20",
     "mobx": "5.15.7",
     "mobx-react": "6.3.1",
     "mocha": "8.2.1",

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -134,7 +134,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
           unparsedEntryModules[0].parsedSrc = assetSources.runtimeSrc;
         } else {
           // If there are multiple entry points we move all of them under synthetic concatenated module.
-          assetModules = assetModules.filter(m => !unparsedEntryModules.includes(m))
+          assetModules = assetModules.filter(m => !unparsedEntryModules.includes(m));
           assetModules.unshift({
             identifier: './entry modules',
             name: './entry modules',

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -181,14 +181,12 @@ function getBundleModules(bundleStats) {
   return (bundleStats.chunks || [])
     .reduce((result, item) => result.concat(item.modules), [])
     .concat(bundleStats.modules)
+    .filter(item => item != null)
+    // Filtering out Webpack's runtime modules as they don't have ids and can't be parsed (introduced in Webpack 5)
+    .filter(item => !isRuntimeModule(item))
+    // deduplicate modules
     .reduce((result, item) => {
-      if (
-        item != null &&
-        // Filtering out Webpack's runtime modules as they don't have ids and can't be parsed (introduced in Webpack 5)
-        !isRuntimeModule(item) &&
-        // deduplicate modules
-        !result.some(m => m.id === item.id)
-      ) {
+      if (!result.some(m => m.id === item.id)) {
         result.push(item);
       }
       return result;

--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const _ = require('lodash');
 const acorn = require('acorn');
 const walk = require('acorn-walk');
 
@@ -140,14 +139,14 @@ function parseBundle(bundlePath) {
     }
   );
 
-  let modules;
+  const modules = {};
 
   if (walkState.locations) {
-    modules = _.mapValues(walkState.locations,
-      loc => content.slice(loc.start, loc.end)
+    Object.entries(walkState.locations).forEach(
+      ([path, loc]) => {
+        modules[path] = content.slice(loc.start, loc.end)
+      }
     );
-  } else {
-    modules = {};
   }
 
   return {

--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -144,7 +144,7 @@ function parseBundle(bundlePath) {
   if (walkState.locations) {
     Object.entries(walkState.locations).forEach(
       ([path, loc]) => {
-        modules[path] = content.slice(loc.start, loc.end)
+        modules[path] = content.slice(loc.start, loc.end);
       }
     );
   }

--- a/src/tree/BaseFolder.js
+++ b/src/tree/BaseFolder.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import Node from './Node';
 
 export default class BaseFolder extends Node {
@@ -10,7 +8,7 @@ export default class BaseFolder extends Node {
   }
 
   get src() {
-    if (!_.has(this, '_src')) {
+    if (!('_src' in this)) {
       this._src = this.walk((node, src) => (src += node.src || ''), '', false);
     }
 
@@ -18,7 +16,7 @@ export default class BaseFolder extends Node {
   }
 
   get size() {
-    if (!_.has(this, '_size')) {
+    if (!('_size' in this)) {
       this._size = this.walk((node, size) => (size + node.size), 0, false);
     }
 
@@ -111,7 +109,7 @@ export default class BaseFolder extends Node {
       label: this.name,
       path: this.path,
       statSize: this.size,
-      groups: _.invokeMap(this.children, 'toChartData')
+      groups: Object.values(this.children).map(item => item.toChartData())
     };
   }
 

--- a/src/tree/ConcatenatedModule.js
+++ b/src/tree/ConcatenatedModule.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import Module from './Module';
 import ContentModule from './ContentModule';
 import ContentFolder from './ContentFolder';
@@ -25,7 +23,7 @@ export default class ConcatenatedModule extends Module {
       return;
     }
 
-    const [folders, fileName] = [pathParts.slice(0, -1), _.last(pathParts)];
+    const [folders, fileName] = [pathParts.slice(0, -1), pathParts[pathParts.length - 1]];
     let currentFolder = this;
 
     folders.forEach(folderName => {
@@ -58,14 +56,18 @@ export default class ConcatenatedModule extends Module {
   }
 
   mergeNestedFolders() {
-    _.invokeMap(this.children, 'mergeNestedFolders');
+    Object.values(this.children).forEach(item => {
+      if (item.mergeNestedFolders) {
+        item.mergeNestedFolders();
+      }
+    });
   }
 
   toChartData() {
     return {
       ...super.toChartData(),
       concatenated: true,
-      groups: _.invokeMap(this.children, 'toChartData')
+      groups: Object.values(this.children).map(item => item.toChartData())
     };
   }
 

--- a/src/tree/Folder.js
+++ b/src/tree/Folder.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import gzipSize from 'gzip-size';
 
 import Module from './Module';
@@ -13,7 +12,7 @@ export default class Folder extends BaseFolder {
   }
 
   get gzipSize() {
-    if (!_.has(this, '_gzipSize')) {
+    if (!('_gzipSize' in this)) {
       this._gzipSize = this.src ? gzipSize.sync(this.src) : 0;
     }
 
@@ -27,7 +26,7 @@ export default class Folder extends BaseFolder {
       return;
     }
 
-    const [folders, fileName] = [pathParts.slice(0, -1), _.last(pathParts)];
+    const [folders, fileName] = [pathParts.slice(0, -1), pathParts[pathParts.length - 1]];
     let currentFolder = this;
 
     folders.forEach(folderName => {

--- a/src/tree/Module.js
+++ b/src/tree/Module.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import gzipSize from 'gzip-size';
 
 import Node from './Node';
@@ -32,7 +31,7 @@ export default class Module extends Node {
   }
 
   get gzipSize() {
-    if (!_.has(this, '_gzipSize')) {
+    if (!('_gzipSize' in this)) {
       this._gzipSize = this.src ? gzipSize.sync(this.src) : undefined;
     }
 

--- a/src/tree/utils.js
+++ b/src/tree/utils.js
@@ -5,7 +5,7 @@ export function getModulePathParts(moduleData) {
     return [moduleData.identifier];
   }
 
-  const parts = moduleData.name.split('!')
+  const parts = moduleData.name.split('!');
 
   // Removing loaders from module path: they're joined by `!` and the last part is a raw module path
   const parsedPath = parts[parts.length - 1]

--- a/src/tree/utils.js
+++ b/src/tree/utils.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 const MULTI_MODULE_REGEXP = /^multi /u;
 
 export function getModulePathParts(moduleData) {
@@ -7,9 +5,10 @@ export function getModulePathParts(moduleData) {
     return [moduleData.identifier];
   }
 
-  const parsedPath = _
+  const parts = moduleData.name.split('!')
+
   // Removing loaders from module path: they're joined by `!` and the last part is a raw module path
-    .last(moduleData.name.split('!'))
+  const parsedPath = parts[parts.length - 1]
     // Splitting module path into parts
     .split('/')
     // Removing first `.`

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 const {inspect, types} = require('util');
-const _ = require('lodash');
 const opener = require('opener');
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -7,9 +6,8 @@ const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', '
 exports.createAssetsFilter = createAssetsFilter;
 
 function createAssetsFilter(excludePatterns) {
-  const excludeFunctions = _(excludePatterns)
-    .castArray()
-    .compact()
+  const excludeFunctions = (Array.isArray(excludePatterns) ? excludePatterns : [excludePatterns])
+    .filter(pattern => pattern != null)
     .map(pattern => {
       if (typeof pattern === 'string') {
         pattern = new RegExp(pattern, 'u');
@@ -26,8 +24,7 @@ function createAssetsFilter(excludePatterns) {
       }
 
       return pattern;
-    })
-    .value();
+    });
 
   if (excludeFunctions.length) {
     return (asset) => excludeFunctions.every(fn => fn(asset) !== true);

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3,10 +3,10 @@ const fs = require('fs');
 const http = require('http');
 
 const WebSocket = require('ws');
-const _ = require('lodash');
 const express = require('express');
 const ejs = require('ejs');
 const {bold} = require('chalk');
+const {isPlainObject} = require('is-plain-object');
 
 const Logger = require('./Logger');
 const analyzer = require('./analyzer');
@@ -221,7 +221,7 @@ function getChartData(analyzerOpts, ...args) {
     chartData = null;
   }
 
-  if (_.isPlainObject(chartData) && _.isEmpty(chartData)) {
+  if (isPlainObject(chartData) && Object.keys(chartData).length === 0) {
     logger.error("Could't find any javascript bundles in provided stats file");
     chartData = null;
   }


### PR DESCRIPTION
Lodash is quite big package and often overused for things available
natively. In this diff I removed it from package dependencies and left
only for tests.