### PR TITLE
Draw FoamTree labels also during animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 ## UNRELEASED
 
-<!-- Add changelog entries for new changes under this section -->
-
+* **Improvement**
+  * Keep treemap labels visible during zooming animations for better user experience ([#414](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/414) by [@
+    stanislawosinski](https://github.com/stanislawosinski))
+    
 ## 4.3.0
 
  * **Improvement**

--- a/client/components/Treemap.jsx
+++ b/client/components/Treemap.jsx
@@ -62,6 +62,7 @@ export default class Treemap extends Component {
       maxGroupLevelsDrawn: Infinity,
       maxGroupLabelLevelsDrawn: Infinity,
       maxGroupLevelsAttached: Infinity,
+      wireframeLabelDrawing: 'always',
       groupMinDiameter: 0,
       groupLabelVerticalPadding: 0.2,
       rolloutDuration: 0,


### PR DESCRIPTION
This should improve the user experience and should still be fairly smooth on recent hardware.