### PR TITLE
Support reading large stats.json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 ## UNRELEASED
 
+ * **Improvement**
+   * Support reading large (>500MB) stats.json files ([#423](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/423) by [@henry-alakazhang](https://github.com/henry-alakazhang))
+
 ## 4.7.0
 
  * **New Feature**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1258,6 +1258,12 @@
       "integrity": "sha512-cDql5T3eS4Y5jzrDj25QNpU0pHgLFJ96MaoMAkJX8ceL2yat4u7EbIuqLoTbQLiTy1KxDRFbxHIKLzTUT64Duw==",
       "dev": true
     },
+    "@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1261,8 +1261,7 @@
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
-      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
-      "dev": true
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@babel/preset-react": "7.13.13",
     "@babel/runtime": "7.14.0",
     "@carrotsearch/foamtree": "3.5.0",
+    "@discoveryjs/json-ext": "0.5.7",
     "autoprefixer": "10.2.5",
     "babel-eslint": "10.1.0",
     "babel-loader": "8.2.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lib"
   ],
   "dependencies": {
+    "@discoveryjs/json-ext": "0.5.7",
     "acorn": "^8.0.4",
     "acorn-walk": "^8.0.0",
     "chalk": "^4.1.0",
@@ -51,7 +52,6 @@
     "@babel/preset-react": "7.13.13",
     "@babel/runtime": "7.14.0",
     "@carrotsearch/foamtree": "3.5.0",
-    "@discoveryjs/json-ext": "0.5.7",
     "autoprefixer": "10.2.5",
     "babel-eslint": "10.1.0",
     "babel-loader": "8.2.2",

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const _ = require('lodash');
 const gzipSize = require('gzip-size');
+const {parseChunked} = require('@discoveryjs/json-ext');
 
 const Logger = require('./Logger');
 const Folder = require('./tree/Folder').default;
@@ -164,8 +165,8 @@ function getViewerData(bundleStats, bundleDir, opts) {
 }
 
 function readStatsFromFile(filename) {
-  return JSON.parse(
-    fs.readFileSync(filename, 'utf8')
+  return parseChunked(
+    fs.createReadStream(filename, {encoding: 'utf8'})
   );
 }
 

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -110,44 +110,46 @@ bundleStatsFile = resolve(bundleStatsFile);
 
 if (!bundleDir) bundleDir = dirname(bundleStatsFile);
 
-let bundleStats;
-try {
-  bundleStats = analyzer.readStatsFromFile(bundleStatsFile);
-} catch (err) {
-  logger.error(`Couldn't read webpack bundle stats from "${bundleStatsFile}":\n${err}`);
-  logger.debug(err.stack);
-  process.exit(1);
-}
+parseAndAnalyse(bundleStatsFile);
 
-if (mode === 'server') {
-  viewer.startServer(bundleStats, {
-    openBrowser,
-    port,
-    host,
-    defaultSizes,
-    reportTitle,
-    bundleDir,
-    excludeAssets,
-    logger: new Logger(logLevel),
-    analyzerUrl: utils.defaultAnalyzerUrl
-  });
-} else if (mode === 'static') {
-  viewer.generateReport(bundleStats, {
-    openBrowser,
-    reportFilename: resolve(reportFilename || 'report.html'),
-    reportTitle,
-    defaultSizes,
-    bundleDir,
-    excludeAssets,
-    logger: new Logger(logLevel)
-  });
-} else if (mode === 'json') {
-  viewer.generateJSONReport(bundleStats, {
-    reportFilename: resolve(reportFilename || 'report.json'),
-    bundleDir,
-    excludeAssets,
-    logger: new Logger(logLevel)
-  });
+async function parseAndAnalyse(bundleStatsFile) {
+  try {
+    const bundleStats = await analyzer.readStatsFromFile(bundleStatsFile);
+    if (mode === 'server') {
+      viewer.startServer(bundleStats, {
+        openBrowser,
+        port,
+        host,
+        defaultSizes,
+        reportTitle,
+        bundleDir,
+        excludeAssets,
+        logger: new Logger(logLevel),
+        analyzerUrl: utils.defaultAnalyzerUrl
+      });
+    } else if (mode === 'static') {
+      viewer.generateReport(bundleStats, {
+        openBrowser,
+        reportFilename: resolve(reportFilename || 'report.html'),
+        reportTitle,
+        defaultSizes,
+        bundleDir,
+        excludeAssets,
+        logger: new Logger(logLevel)
+      });
+    } else if (mode === 'json') {
+      viewer.generateJSONReport(bundleStats, {
+        reportFilename: resolve(reportFilename || 'report.json'),
+        bundleDir,
+        excludeAssets,
+        logger: new Logger(logLevel)
+      });
+    }
+  } catch (err) {
+    logger.error(`Couldn't read webpack bundle stats from "${bundleStatsFile}":\n${err}`);
+    logger.debug(err.stack);
+    process.exit(1);
+  }
 }
 
 function showHelp(error) {


### PR DESCRIPTION
Node has a string size limit of 500MB and the current `JSON.parse(fs.readFileSync(...))` logic to read `stats.json` files fails for files >500MB.

This PR changes the approach for stats parsing to use a stream, similar to this PR for webpack-cli in creating the file: https://github.com/webpack/webpack-cli/pull/2190

I've tested it against a local repo with a 700MB stats.json and it works when it didn't before. I would add a test, but I don't know about adding that large of a file :joy: Could look into generating one if you would like.