### PR TITLE
check this.compiler.outputFileSystem.constructor is not undefined

### DIFF
--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -134,6 +134,9 @@ class BundleAnalyzerPlugin {
   }
 
   getBundleDirFromCompiler() {
+    if (typeof this.compiler.outputFileSystem.constructor === 'undefined') {
+      return this.compiler.outputPath;
+    }    
     switch (this.compiler.outputFileSystem.constructor.name) {
       case 'MemoryFileSystem':
         return null;


### PR DESCRIPTION
via https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/384#issuecomment-838827301

In some cases, `this.compiler.outputFileSystem.constructor` can be undefined, causing access to properties on this to fail. This PR adds a check to prevent this.