### PR TITLE
Add module reasons array

### DIFF
--- a/src/tree/Module.js
+++ b/src/tree/Module.js
@@ -51,7 +51,7 @@ export default class Module extends Node {
 
   toChartData() {
     const reasonsNames = _(this.data.reasons)
-      .map('module')
+      .map('moduleName')
       .compact()
       .value();
 


### PR DESCRIPTION
Following this issue https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/269 and this branch https://github.com/webpack-contrib/webpack-bundle-analyzer/tree/module-import-reasons.
I add the reasons array to module so it will be in the analyzed report.
UI is still needs to be handle.