### PR TITLE
fix: stop publishing src folder to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   },
   "files": [
     "public",
-    "lib",
-    "src"
+    "lib"
   ],
   "dependencies": {
     "acorn": "^8.0.4",


### PR DESCRIPTION
fix #472 