### PR TITLE
fix: can't setup with cli mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 ## UNRELEASED
 
+* **Bug Fix** 
+  * fix outputting different URL in cli mode ([#524](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/524) by [@southorange1228](https://github.com/southorange1228))
+
 ## 4.6.0
 
 * **New Feature** 

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -128,7 +128,8 @@ if (mode === 'server') {
     reportTitle,
     bundleDir,
     excludeAssets,
-    logger: new Logger(logLevel)
+    logger: new Logger(logLevel),
+    analyzerUrl: utils.defaultAnalyzerUrl
   });
 } else if (mode === 'static') {
   viewer.generateReport(bundleStats, {


### PR DESCRIPTION
Last weak, i submit a feature about custom analyzerUrl.But i'm sorry that i'm not changed `cli mode`logic. It carsed error then use cli to start server.

refer issue: https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/523