### PR TITLE
feat: gray out non-matches when searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
  * **Improvement**
    * Support reading large (>500MB) stats.json files ([#423](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/423) by [@henry-alakazhang](https://github.com/henry-alakazhang))
+   * Improve search UX by graying out non-matches ([#554](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/554) by [@starpit](https://github.com/starpit))
 
 ## 4.7.0
 

--- a/client/components/Treemap.jsx
+++ b/client/components/Treemap.jsx
@@ -22,11 +22,7 @@ export default class Treemap extends Component {
         dataObject: this.getTreemapDataObject(nextProps.data)
       });
     } else if (nextProps.highlightGroups !== this.props.highlightGroups) {
-      const groupsToRedraw = [
-        ...nextProps.highlightGroups,
-        ...this.props.highlightGroups
-      ];
-      setTimeout(() => this.treemap.redraw(false, groupsToRedraw));
+      setTimeout(() => this.treemap.redraw());
     }
   }
 
@@ -102,6 +98,11 @@ export default class Treemap extends Component {
             b: 0,
             a: 0.8
           };
+        } else if (highlightGroups && highlightGroups.size > 0) {
+          // this means a search (e.g.) is active, but this module
+          // does not match; gray it out
+          // https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/553
+          variables.groupColor.s = 10;
         }
       },
       /**


### PR DESCRIPTION
This PR reduces the saturation (from 60 to 10) for non-matches.

Note: there seems to be a bug in foamtree? It does not redraw some of the nodes until you hover over them. This seems to be a preexisting issue.

Fixes #553

<img width="2076" alt="Screenshot 2023-01-30 at 11 00 33 AM" src="https://user-images.githubusercontent.com/4741620/215528387-d91343cf-994c-4fea-87d9-840eaefce9f0.png">

<details><summary>Click to see the outdated details about the <code>.redraw()</code> behavior we've discussed in this PR</summary>

## FoamTree bug?

This gif shows how randomly some of the nodes are not redrawn (by foamtree) until you hover over them. I think this bug is masked by the current highlighting behavior, which does not change the color of non-matching nodes.
![foamtree-oddity](https://user-images.githubusercontent.com/4741620/215529107-076ee052-8913-4013-bf0d-90194bc53fe5.gif)


</details>