### PR TITLE
improvement: Display more detailed module information for concatenated entry modules

### DIFF
--- a/src/tree/ConcatenatedModule.js
+++ b/src/tree/ConcatenatedModule.js
@@ -38,7 +38,8 @@ export default class ConcatenatedModule extends Module {
       currentFolder = childFolder;
     });
 
-    const module = new ContentModule(fileName, moduleData, this);
+    const ModuleConstructor = moduleData.modules ? ConcatenatedModule : ContentModule;
+    const module = new ModuleConstructor(fileName, moduleData, this);
     currentFolder.addChildModule(module);
   }
 


### PR DESCRIPTION
After migrating a large monorepo from Webpack 4 to Webpack 5, we noticed that we lost detailed entry module information, which made the bundle analyzer reports much less useful for us. After looking a little bit through the `webpack-bundle-analyzer` repo, I found this comment: https://github.com/webpack-contrib/webpack-bundle-analyzer/blob/e231c77064329fdd586e2e69f65d24f9a5a2004a/src/analyzer.js#L124-L126

Although we can't determine the parsed sizes of the concatenated modules, that shouldn't prevent us from displaying what modules are actually included in the concatenated entry module when viewing stat sizes. This is what our current report looks like for entry modules (with Stat sizes selected and "Show content of concatenated modules" checked):

<img width="1130" alt="image" src="https://github.com/webpack-contrib/webpack-bundle-analyzer/assets/21962852/739eb955-1fd6-4e42-a4f4-a21b236a221e">

After this change, here is what that same view looks like:

<img width="1128" alt="image" src="https://github.com/webpack-contrib/webpack-bundle-analyzer/assets/21962852/7e51ae47-edb7-4213-b118-dcdfb175af30">
