### PR TITLE
bump sirv to fix analyzerMode server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
   * Replace some lodash usages with JavaScript native API ([#505](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/505)) by [@sukkaw](https://github.com/sukkaw).
   * Make module much slimmer ([#609](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/609)) by [@sukkaw](https://github.com/sukkaw).
 
+* **Bug Fix**
+  * fix `analyzerMode: 'server'` on certain machines ([#611](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/611) by [@panbenson](https://github.com/panbenson))
+
 ## 4.9.0
 
 * **Improvement**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1675,9 +1675,9 @@
       }
     },
     "@polka/url": {
-      "version": "1.0.0-next.12",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.12.tgz",
-      "integrity": "sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ=="
+      "version": "1.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -8407,7 +8407,8 @@
     "mime": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.47.0",
@@ -8512,6 +8513,11 @@
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-2.2.2.tgz",
       "integrity": "sha512-2SlXALHIkyUPDsV4VTKVR9DW7K3Ksh1aaIv3NrNJygTbhXe2A9GrcKHZ2ovIiOp/BXilOcTYemfHHZubP431dg==",
       "dev": true
+    },
+    "mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw=="
     },
     "ms": {
       "version": "2.1.2",
@@ -10789,13 +10795,13 @@
       "dev": true
     },
     "sirv": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.11.tgz",
-      "integrity": "sha512-SR36i3/LSWja7AJNRBz4fF/Xjpn7lQFI30tZ434dIy+bitLYSP+ZEenHg36i23V2SGEz+kqjksg0uOGZ5LPiqg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
+      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
       "requires": {
-        "@polka/url": "^1.0.0-next.9",
-        "mime": "^2.3.1",
-        "totalist": "^1.0.0"
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^3.0.0"
       }
     },
     "sisteransi": {
@@ -11791,9 +11797,9 @@
       "dev": true
     },
     "totalist": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
-      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="
     },
     "tough-cookie": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash.uniqby": "^4.7.0",
     "opener": "^1.5.2",
     "picocolors": "^1.0.0",
-    "sirv": "^1.0.7",
+    "sirv": "^2.0.3",
     "ws": "^7.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
i'm unable to start webpack-bundle-analyzer@4.9.0 in `'server'` mode with the following traceback:

```
node_modules/webpack-bundle-analyzer/lib/viewer.js:89
      sirvMiddleware(req, res);
      ^
TypeError: parser is not a function
    at node_modules/webpack-bundle-analyzer/node_modules/sirv/build.js:163:30
    at Server.<anonymous> (node_modules/webpack-bundle-analyzer/lib/viewer.js:89:7)
    at Server.emit (node:events:513:28)
    at Server.emit (node:domain:489:12)
    at parserOnIncoming (node:_http_server:1068:12)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)
```

it appears to be related to `sirv`, and a fix for this issue (https://github.com/lukeed/sirv/issues/124) was released in [`^2.0.0`](https://github.com/lukeed/sirv/releases/tag/v2.0.0). i've confirmed adding a resolution for this package lets me boot webpack-bundle-analyzer in `'server'` mode on my project.

also ran `npm test` locally with these changes