### PR TITLE
(WIP) Drop all `lodash.*` packages

### DIFF
--- a/client/components/ModuleItem.jsx
+++ b/client/components/ModuleItem.jsx
@@ -1,5 +1,5 @@
 import escapeRegExp from 'escape-string-regexp';
-import escape from 'lodash.escape';
+import {escape} from 'html-escaper';
 import filesize from 'filesize';
 import cls from 'classnames';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6142,8 +6142,7 @@
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -8103,11 +8102,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
     },
     "lodash.flatten": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "engines": {
     "node": ">= 10.13.0"
   },
+  "packageManager": "npm@6.14.8",
   "scripts": {
     "start": "gulp watch",
     "build": "gulp build",
@@ -38,9 +39,9 @@
     "commander": "^7.2.0",
     "escape-string-regexp": "^4.0.0",
     "gzip-size": "^6.0.0",
+    "html-escaper": "^2.0.2",
     "is-plain-object": "^5.0.0",
     "lodash.debounce": "^4.0.8",
-    "lodash.escape": "^4.0.1",
     "lodash.flatten": "^4.4.0",
     "lodash.invokemap": "^4.6.0",
     "lodash.pullall": "^4.2.0",

--- a/src/template.js
+++ b/src/template.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const fs = require('fs');
 
-const escape = require('lodash.escape');
+const {escape} = require('html-escaper');
 
 const projectRoot = path.resolve(__dirname, '..');
 const assetsRoot = path.join(projectRoot, 'public');


### PR DESCRIPTION
This is WIP.

- `lodash.escape` -> `html-escaper`