### PR TITLE
fix: handleValueChange.cancel is not a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 ## UNRELEASED
 
+* **Bug Fix**
+  * fix `this.handleValueChange.cancel()` is not a function ([#611](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/625) by [@life2015](https://github.com/life2015))
+
 ## 4.10.0
 
 * **Improvement**
@@ -19,9 +22,6 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 * **Internal**
   * Make module much slimmer by replacing all `lodash.*` packages ([#612](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/612)) by [@sukkaw](https://github.com/sukkaw).
-
-* **Bug Fix**
-  * fix `this.handleValueChange.cancel()` is not a function ([#611](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/625) by [@life2015](https://github.com/life2015))
 
 ## 4.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 * **Internal**
   * Make module much slimmer by replacing all `lodash.*` packages ([#612](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/612)) by [@sukkaw](https://github.com/sukkaw).
 
+* **Bug Fix**
+  * fix `this.handleValueChange.cancel()` is not a function ([#611](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/625) by [@life2015](https://github.com/life2015))
+
 ## 4.9.1
 
 * **Internal**

--- a/client/components/Search.jsx
+++ b/client/components/Search.jsx
@@ -14,7 +14,7 @@ export default class Search extends PureComponent {
   }
 
   componentWillUnmount() {
-    this.handleValueChange.cancel();
+    this.handleValueChange.clear();
   }
 
   render() {
@@ -79,7 +79,7 @@ export default class Search extends PureComponent {
   }
 
   clear() {
-    this.handleValueChange.cancel();
+    this.handleValueChange.clear();
     this.informChange('');
     this.input.value = '';
   }


### PR DESCRIPTION
<img width="797" alt="image" src="https://github.com/webpack-contrib/webpack-bundle-analyzer/assets/12879047/4b3d31ab-902a-4013-825f-29aefc86a820">

The error "this.handleValueChange.cancel is not a function" often occurs when I use webpack-bundle-analyzer, leading to a paralysis of page interaction. 

Therefore, I have made some defensive fixes in the code here. After the fixes, the generated static pages now perform normally.
