### PR TITLE
Remove `is-plain-object`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6819,11 +6819,6 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
-    "is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-    },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "escape-string-regexp": "^4.0.0",
     "gzip-size": "^6.0.0",
     "html-escaper": "^2.0.2",
-    "is-plain-object": "^5.0.0",
     "opener": "^1.5.2",
     "picocolors": "^1.0.0",
     "sirv": "^2.0.3",

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4,7 +4,6 @@ const http = require('http');
 
 const WebSocket = require('ws');
 const sirv = require('sirv');
-const {isPlainObject} = require('is-plain-object');
 const {bold} = require('picocolors');
 
 const Logger = require('./Logger');
@@ -190,7 +189,12 @@ function getChartData(analyzerOpts, ...args) {
     chartData = null;
   }
 
-  if (isPlainObject(chartData) && Object.keys(chartData).length === 0) {
+  // chartData can either be an array (bundleInfo[]) or null. It can't be an plain object anyway
+  if (
+    // analyzer.getViewerData() doesn't failed in the previous step
+    chartData
+    && !Array.isArray(chartData)
+  ) {
     logger.error("Could't find any javascript bundles in provided stats file");
     chartData = null;
   }
@@ -199,8 +203,8 @@ function getChartData(analyzerOpts, ...args) {
 }
 
 function getEntrypoints(bundleStats) {
-  if (bundleStats === null || bundleStats === undefined) {
+  if (bundleStats === null || bundleStats === undefined || !bundleStats.entrypoints) {
     return [];
   }
-  return Object.values(bundleStats.entrypoints || {}).map(entrypoint => entrypoint.name);
+  return Object.values(bundleStats.entrypoints).map(entrypoint => entrypoint.name);
 }


### PR DESCRIPTION
The PR removes a dependency `is-plain-object`, further reducing the installation size.

Ref #505 #609 #612

Turns out that the return value of `analyzer.getViewerData()` is always an array (from `Object.entries`), we can safely remove the `is-plain-object` guard.