### PR TITLE
Fixes #427, #556 use correct `sourceType` when parsing bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 ## UNRELEASED
 
+* **Improvement**
+  * Parse bundles as ES modules based on stats JSON information
+
 ## 4.10.2
 
 * **Bug Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 ## UNRELEASED
 
 * **Improvement**
-  * Parse bundles as ES modules based on stats JSON information
+  * Parse bundles as ES modules based on stats JSON information ([#649](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/649) by [@eamodio](https://github.com/eamodio))
 
 ## 4.10.2
 

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -77,7 +77,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
       let bundleInfo;
 
       try {
-        bundleInfo = parseBundle(assetFile);
+        bundleInfo = parseBundle(assetFile, {sourceType: statAsset.info.javascriptModule ? 'module' : 'script'});
       } catch (err) {
         const msg = (err.code === 'ENOENT') ? 'no such file' : err.message;
         logger.warn(`Error parsing bundle asset "${assetFile}": ${msg}`);

--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -6,10 +6,14 @@ module.exports = {
   parseBundle
 };
 
-function parseBundle(bundlePath) {
+function parseBundle(bundlePath, opts) {
+  const {
+    sourceType = 'script'
+  } = opts || {};
+
   const content = fs.readFileSync(bundlePath, 'utf8');
   const ast = acorn.parse(content, {
-    sourceType: 'script',
+    sourceType,
     // I believe in a bright future of ECMAScript!
     // Actually, it's set to `2050` to support the latest ECMAScript version that currently exists.
     // Seems like `acorn` supports such weird option value.


### PR DESCRIPTION
Refs #427, #556

We are now parsing bundles as ES modules based on stats JSON information