### PR TITLE
fix: allow react native bundle files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 * **New Feature**
   * Add support for Brotli compression ([#663](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/663) by [@dcsaszar](https://github.com/dcsaszar))
+  * Add support for React Native ([666](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/666) by [@ilteoood](https://github.com/ilteoood))
 
 ## 4.10.2
 

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -10,7 +10,7 @@ const {createAssetsFilter} = require('./utils');
 const {getCompressedSize} = require('./sizeUtils');
 
 const FILENAME_QUERY_REGEXP = /\?.*$/u;
-const FILENAME_EXTENSIONS = /\.(js|mjs|cjs)$/iu;
+const FILENAME_EXTENSIONS = /\.(js|mjs|cjs|bundle)$/iu;
 
 module.exports = {
   getViewerData,


### PR DESCRIPTION
Thanks to Re-Pack, now even React Native projects can use Rspack or Webpack as a bundler instead of Metro.
We would like to use webpack-bundle-analyzer to discover the pain point of our app.
Unfortunately, the React Native assets are stored in a `.bundle` size: this is forcing us to patch `webpack-bundle-analyzer` to be able to use it.

With this PR, I'm going to address it.