### PR TITLE
allow to catch parsing errors

### DIFF
--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -81,7 +81,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
         bundleInfo = parseBundle(assetFile, {sourceType: statAsset.info.javascriptModule ? 'module' : 'script'});
       } catch (err) {
         const msg = (err.code === 'ENOENT') ? 'no such file' : err.message;
-        logger.warn(`Error parsing bundle asset "${assetFile}": ${msg}`);
+        logger.warn(`Error parsing bundle asset "${assetFile}": ${msg}`, { cause: err });
         continue;
       }
 

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -81,7 +81,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
         bundleInfo = parseBundle(assetFile, {sourceType: statAsset.info.javascriptModule ? 'module' : 'script'});
       } catch (err) {
         const msg = (err.code === 'ENOENT') ? 'no such file' : err.message;
-        logger.warn(`Error parsing bundle asset "${assetFile}": ${msg}`, { cause: err });
+        logger.warn(`Error parsing bundle asset "${assetFile}": ${msg}`, {cause: err});
         continue;
       }
 


### PR DESCRIPTION
Now you can see:
```
Error parsing bundle asset "/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/dist/public/index.mjs": Cannot read properties of undefined (reading 'arguments') {
  cause: TypeError: Cannot read properties of undefined (reading 'arguments')
      at getModulesLocations (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/webpack-bundle-analyzer/lib/parseUtils.js:254:24)
      at Object.ExpressionStatement (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/webpack-bundle-analyzer/lib/parseUtils.js:44:35)
      at c (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/acorn-walk/dist/walk.js:58:37)
      at Object.skipThrough (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/acorn-walk/dist/walk.js:186:39)
      at c (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/acorn-walk/dist/walk.js:58:37)
      at base.Program.base.BlockStatement.base.StaticBlock (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/acorn-walk/dist/walk.js:198:7)
      at c (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/acorn-walk/dist/walk.js:58:37)
      at Object.recursive (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/acorn-walk/dist/walk.js:59:7)
      at parseBundle (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/webpack-bundle-analyzer/lib/parseUtils.js:26:8)
      at Object.getViewerData (/home/alexander-akait/IdeaProjects/webpack-bundle-analyzer-reproducer-409/node_modules/webpack-bundle-analyzer/lib/analyzer.js:87:22)
}
```

Useful for https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/409#issuecomment-3134857678