### PR TITLE
fix: handle child stats without root assets

### DIFF
--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -230,6 +230,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
   ) {
     const { children } = bundleStats;
     [bundleStats] = bundleStats.children;
+    bundleStats.assets ||= [];
     // Sometimes if there are additional child chunks produced add them as child assets,
     // leave the 1st one as that is considered the 'root' asset.
     for (let i = 1; i < children.length; i++) {

--- a/test/analyzer-get-viewer-data.js
+++ b/test/analyzer-get-viewer-data.js
@@ -1,0 +1,48 @@
+const analyzer = require("../src/analyzer");
+
+describe("getViewerData", () => {
+  it("handles child stats when the root child has no assets", () => {
+    const chartData = analyzer.getViewerData(
+      {
+        assets: [],
+        children: [
+          {
+            chunks: [],
+            modules: [],
+          },
+          {
+            assets: [
+              {
+                chunks: [1],
+                name: "child.js",
+                size: 12,
+              },
+            ],
+            chunks: [
+              {
+                id: 1,
+                modules: [
+                  {
+                    chunks: [1],
+                    id: 1,
+                    identifier: "./child.js",
+                    name: "./child.js",
+                    size: 12,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      null,
+    );
+
+    expect(chartData).toMatchObject([
+      {
+        label: "child.js",
+        statSize: 12,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Initialize the selected child stats object's `assets` array before appending assets from later child compilations.

## Why

When root stats contain only `children`, and the first child has no `assets` while a later child does, `getViewerData()` currently tries to push into `undefined` and crashes before producing chart data. This is one of the missing-stats-shape cases discussed in #490.

## How

Added a focused regression test for that stats shape and guarded the selected child stats with an empty `assets` array before merging later child assets.

## Validation

- `NODE_OPTIONS=--openssl-legacy-provider npx jest test/analyzer-get-viewer-data.js --runInBand` failed before the fix with `Cannot read properties of undefined (reading 'push')`
- `NODE_OPTIONS=--openssl-legacy-provider npx jest test/analyzer-get-viewer-data.js --runInBand`
- `npm run build`
- `NODE_OPTIONS=--openssl-legacy-provider npx jest test/analyzer-get-viewer-data.js test/analyzer.js --runInBand --testTimeout=60000`
- `npm run lint`
- `git diff --check`

Note: I also tried the full Jest suite with `--testTimeout=60000`; the analyzer tests passed, but the run failed in `test/plugin.js` after 128 passed / 4 skipped due to a local Puppeteer `afterEach` browser cleanup timeout.
