### PR TITLE
fix: request analyzer stats fields

### DIFF
--- a/.changeset/fair-forks-tap.md
+++ b/.changeset/fair-forks-tap.md
@@ -2,4 +2,4 @@
 "webpack-bundle-analyzer": patch
 ---
 
-Ensure analyzer modes request the stats fields needed for bundle analysis.
+Explicitly define `stats.toJson()` options for bundle analysis to support Rspack 2.0 with minimal code changes needed.

--- a/.changeset/fair-forks-tap.md
+++ b/.changeset/fair-forks-tap.md
@@ -1,0 +1,5 @@
+---
+"webpack-bundle-analyzer": patch
+---
+
+Ensure analyzer modes request the stats fields needed for bundle analysis.

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -30,6 +30,32 @@ const viewer = require("./viewer");
 /** @typedef {string | (() => string)} ReportTitle */
 /** @typedef {(options: { listenHost: string, listenPort: number, boundAddress: string | AddressInfo | null }) => string} AnalyzerUrl */
 
+/** @type {StatsOptions} */
+const analyzerStatsOptions = {
+  all: false,
+  assets: true,
+  cachedAssets: true,
+  cachedModules: true,
+  cached: true,
+  children: true,
+  chunks: true,
+  chunkModules: true,
+  chunkModulesSpace: Number.POSITIVE_INFINITY,
+  depth: true,
+  entrypoints: true,
+  errors: false,
+  errorsCount: false,
+  ids: true,
+  modules: true,
+  modulesSpace: Number.POSITIVE_INFINITY,
+  nestedModules: true,
+  nestedModulesSpace: Number.POSITIVE_INFINITY,
+  runtimeModules: false,
+  source: false,
+  warnings: false,
+  warningsCount: false,
+};
+
 /**
  * @typedef {object} Options
  * @property {Mode=} analyzerMode analyzer mode
@@ -111,11 +137,17 @@ class BundleAnalyzerPlugin {
       }
 
       if (this.opts.analyzerMode === "server") {
-        actions.push(() => this.startAnalyzerServer(stats.toJson()));
+        actions.push(() =>
+          this.startAnalyzerServer(stats.toJson(analyzerStatsOptions)),
+        );
       } else if (this.opts.analyzerMode === "static") {
-        actions.push(() => this.generateStaticReport(stats.toJson()));
+        actions.push(() =>
+          this.generateStaticReport(stats.toJson(analyzerStatsOptions)),
+        );
       } else if (this.opts.analyzerMode === "json") {
-        actions.push(() => this.generateJSONReport(stats.toJson()));
+        actions.push(() =>
+          this.generateJSONReport(stats.toJson(analyzerStatsOptions)),
+        );
       }
 
       if (actions.length) {


### PR DESCRIPTION
## Summary

Rspack 2.0 changed the default `stats.toJson()` output so fields like `modules`, `assets`, `chunks`, `chunkGroups`, and `entryPoints` are no longer included unless requested explicitly. See the [Rspack v2 migration guide](https://rspack.rs/guide/migration/rspack_1.x#changed-default-parameters-of-statstojson).

That can leave webpack-bundle-analyzer with incomplete stats when it runs against Rspack 2.0. This PR makes analyzer modes request the stats fields they need directly instead of relying on compiler defaults.

## Changes

- Add internal stats options for bundle analysis.
- Use them in `server`, `static`, and `json` analyzer modes.
- Keep user-provided `statsOptions` scoped to generated stats files.
- Add regression tests and a patch changeset.

## Notes

`statsOptions` remains user-controlled because users may intentionally filter fields such as assets or modules. Analyzer report generation needs a stable minimum stats shape, so it uses dedicated internal options.

## Validation

- `npm test`
- `npm run lint`
- `npm run build:analyzer`
- `npm run lint:types`
- Targeted Jest, ESLint, and Prettier checks for the touched files.