### PR TITLE
fix: update treemap when chunk selection changes

### DIFF
--- a/.changeset/fix-chunk-selection.md
+++ b/.changeset/fix-chunk-selection.md
@@ -1,0 +1,5 @@
+---
+"webpack-bundle-analyzer": patch
+---
+
+Fix the treemap not reflecting chunk checkbox selections.

--- a/client/components/ModulesTreemap.jsx
+++ b/client/components/ModulesTreemap.jsx
@@ -331,7 +331,7 @@ class ModulesTreemap extends Component {
   };
 
   handleSelectedChunksChange = (selectedChunks) => {
-    store.setSelectedSize(selectedChunks);
+    store.setSelectedChunks(selectedChunks);
   };
 
   handleMouseLeaveTreemap = () => {

--- a/client/viewer.jsx
+++ b/client/viewer.jsx
@@ -5,6 +5,10 @@ import { store } from "./store.js";
 
 import "./viewer.css";
 
+if (globalThis.webpackBundleAnalyzerTest) {
+  globalThis.webpackBundleAnalyzerStore = store;
+}
+
 // Initializing WebSocket for live treemap updates
 let ws;
 try {

--- a/client/viewer.jsx
+++ b/client/viewer.jsx
@@ -5,10 +5,6 @@ import { store } from "./store.js";
 
 import "./viewer.css";
 
-if (globalThis.webpackBundleAnalyzerTest) {
-  globalThis.webpackBundleAnalyzerStore = store;
-}
-
 // Initializing WebSocket for live treemap updates
 let ws;
 try {

--- a/test/analyzer.js
+++ b/test/analyzer.js
@@ -129,24 +129,20 @@ describe("Analyzer", () => {
     generateReportFrom("with-worker-loader-dynamic-import/stats.json");
     const page = await browser.newPage();
     try {
+      await page.evaluateOnNewDocument(() => {
+        globalThis.webpackBundleAnalyzerTest = true;
+      });
       await page.goto(
         url.pathToFileURL(path.resolve(__dirname, "./output/report.html")),
       );
 
-      const { chunkLabel, initialTreemapChunks } = await page.evaluate(() => {
-        const modulesTreemap = document
-          .querySelector("#app")
-          .__k.__k.find(
-            (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
-          ).__c;
-
-        return {
-          chunkLabel: globalThis.chartData[0].label,
-          initialTreemapChunks: modulesTreemap.treemap.props.data.map(
+      const { chunkLabel, initialTreemapChunks } = await page.evaluate(() => ({
+        chunkLabel: globalThis.chartData[0].label,
+        initialTreemapChunks:
+          globalThis.webpackBundleAnalyzerStore.visibleChunks.map(
             (chunk) => chunk.label,
           ),
-        };
-      });
+      }));
 
       const checkboxChecked = await page.evaluate((label) => {
         const checkboxLabel = [...document.querySelectorAll("label")].find(
@@ -158,34 +154,28 @@ describe("Analyzer", () => {
       }, chunkLabel);
 
       await page.waitForFunction(
-        (label) => {
-          const modulesTreemap = document
-            .querySelector("#app")
-            .__k.__k.find(
-              (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
-            ).__c;
-
-          return !modulesTreemap.treemap.props.data.some(
+        (label) =>
+          !globalThis.webpackBundleAnalyzerStore.visibleChunks.some(
             (chunk) => chunk.label === label,
-          );
-        },
+          ),
         {},
         chunkLabel,
       );
 
-      const updatedTreemapChunks = await page.evaluate(() => {
-        const modulesTreemap = document
-          .querySelector("#app")
-          .__k.__k.find(
-            (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
-          ).__c;
-
-        return modulesTreemap.treemap.props.data.map((chunk) => chunk.label);
-      });
+      const { selectedChunks, visibleChunks } = await page.evaluate(() => ({
+        selectedChunks:
+          globalThis.webpackBundleAnalyzerStore.selectedChunks.map(
+            (chunk) => chunk.label,
+          ),
+        visibleChunks: globalThis.webpackBundleAnalyzerStore.visibleChunks.map(
+          (chunk) => chunk.label,
+        ),
+      }));
 
       expect(checkboxChecked).toBe(false);
       expect(initialTreemapChunks).toContain(chunkLabel);
-      expect(updatedTreemapChunks).not.toContain(chunkLabel);
+      expect(selectedChunks).not.toContain(chunkLabel);
+      expect(visibleChunks).not.toContain(chunkLabel);
     } finally {
       await page.close();
     }

--- a/test/analyzer.js
+++ b/test/analyzer.js
@@ -129,20 +129,24 @@ describe("Analyzer", () => {
     generateReportFrom("with-worker-loader-dynamic-import/stats.json");
     const page = await browser.newPage();
     try {
-      await page.evaluateOnNewDocument(() => {
-        globalThis.webpackBundleAnalyzerTest = true;
-      });
       await page.goto(
         url.pathToFileURL(path.resolve(__dirname, "./output/report.html")),
       );
 
-      const { chunkLabel, initialTreemapChunks } = await page.evaluate(() => ({
-        chunkLabel: globalThis.chartData[0].label,
-        initialTreemapChunks:
-          globalThis.webpackBundleAnalyzerStore.visibleChunks.map(
-            (chunk) => chunk.label,
-          ),
-      }));
+      const chunkLabel = await page.evaluate(
+        () => globalThis.chartData[0].label,
+      );
+
+      await page.type('input[placeholder="Enter regexp"]', ".");
+      await page.keyboard.press("Enter");
+      await page.waitForFunction(
+        (label) =>
+          [
+            ...document.querySelectorAll('[class*="foundModulesChunkName"]'),
+          ].some((node) => node.textContent.trim() === label),
+        {},
+        chunkLabel,
+      );
 
       const checkboxChecked = await page.evaluate((label) => {
         const checkboxLabel = [...document.querySelectorAll("label")].find(
@@ -155,27 +159,20 @@ describe("Analyzer", () => {
 
       await page.waitForFunction(
         (label) =>
-          !globalThis.webpackBundleAnalyzerStore.visibleChunks.some(
-            (chunk) => chunk.label === label,
-          ),
+          ![
+            ...document.querySelectorAll('[class*="foundModulesChunkName"]'),
+          ].some((node) => node.textContent.trim() === label),
         {},
         chunkLabel,
       );
 
-      const { selectedChunks, visibleChunks } = await page.evaluate(() => ({
-        selectedChunks:
-          globalThis.webpackBundleAnalyzerStore.selectedChunks.map(
-            (chunk) => chunk.label,
-          ),
-        visibleChunks: globalThis.webpackBundleAnalyzerStore.visibleChunks.map(
-          (chunk) => chunk.label,
-        ),
-      }));
+      const visibleChunkLabels = await page.$$eval(
+        '[class*="foundModulesChunkName"]',
+        (nodes) => nodes.map((node) => node.textContent.trim()),
+      );
 
       expect(checkboxChecked).toBe(false);
-      expect(initialTreemapChunks).toContain(chunkLabel);
-      expect(selectedChunks).not.toContain(chunkLabel);
-      expect(visibleChunks).not.toContain(chunkLabel);
+      expect(visibleChunkLabels).not.toContain(chunkLabel);
     } finally {
       await page.close();
     }

--- a/test/analyzer.js
+++ b/test/analyzer.js
@@ -128,54 +128,67 @@ describe("Analyzer", () => {
   it("should update the treemap when a chunk is deselected", async () => {
     generateReportFrom("with-worker-loader-dynamic-import/stats.json");
     const page = await browser.newPage();
-    await page.goto(
-      url.pathToFileURL(path.resolve(__dirname, "./output/report.html")),
-    );
-
-    const { chunkLabel, initialTreemapChunks } = await page.evaluate(() => {
-      const modulesTreemap = document
-        .querySelector("#app")
-        .__k.__k.find(
-          (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
-        ).__c;
-
-      return {
-        chunkLabel: globalThis.chartData[0].label,
-        initialTreemapChunks: modulesTreemap.treemap.props.data.map(
-          (chunk) => chunk.label,
-        ),
-      };
-    });
-
-    const checkboxChecked = await page.evaluate((label) => {
-      const checkboxLabel = [...document.querySelectorAll("label")].find(
-        (node) => node.textContent.trim().startsWith(`${label} (`),
+    try {
+      await page.goto(
+        url.pathToFileURL(path.resolve(__dirname, "./output/report.html")),
       );
-      const checkbox = checkboxLabel.querySelector('input[type="checkbox"]');
-      checkbox.click();
-      return checkbox.checked;
-    }, chunkLabel);
 
-    await page.evaluate(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(resolve);
-        }),
-    );
+      const { chunkLabel, initialTreemapChunks } = await page.evaluate(() => {
+        const modulesTreemap = document
+          .querySelector("#app")
+          .__k.__k.find(
+            (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
+          ).__c;
 
-    const updatedTreemapChunks = await page.evaluate(() => {
-      const modulesTreemap = document
-        .querySelector("#app")
-        .__k.__k.find(
-          (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
-        ).__c;
+        return {
+          chunkLabel: globalThis.chartData[0].label,
+          initialTreemapChunks: modulesTreemap.treemap.props.data.map(
+            (chunk) => chunk.label,
+          ),
+        };
+      });
 
-      return modulesTreemap.treemap.props.data.map((chunk) => chunk.label);
-    });
+      const checkboxChecked = await page.evaluate((label) => {
+        const checkboxLabel = [...document.querySelectorAll("label")].find(
+          (node) => node.textContent.trim().startsWith(`${label} (`),
+        );
+        const checkbox = checkboxLabel.querySelector('input[type="checkbox"]');
+        checkbox.click();
+        return checkbox.checked;
+      }, chunkLabel);
 
-    expect(checkboxChecked).toBe(false);
-    expect(initialTreemapChunks).toContain(chunkLabel);
-    expect(updatedTreemapChunks).not.toContain(chunkLabel);
+      await page.waitForFunction(
+        (label) => {
+          const modulesTreemap = document
+            .querySelector("#app")
+            .__k.__k.find(
+              (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
+            ).__c;
+
+          return !modulesTreemap.treemap.props.data.some(
+            (chunk) => chunk.label === label,
+          );
+        },
+        {},
+        chunkLabel,
+      );
+
+      const updatedTreemapChunks = await page.evaluate(() => {
+        const modulesTreemap = document
+          .querySelector("#app")
+          .__k.__k.find(
+            (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
+          ).__c;
+
+        return modulesTreemap.treemap.props.data.map((chunk) => chunk.label);
+      });
+
+      expect(checkboxChecked).toBe(false);
+      expect(initialTreemapChunks).toContain(chunkLabel);
+      expect(updatedTreemapChunks).not.toContain(chunkLabel);
+    } finally {
+      await page.close();
+    }
   });
 
   it("should support stats files with modules inside `chunks` array", async () => {

--- a/test/analyzer.js
+++ b/test/analyzer.js
@@ -125,6 +125,59 @@ describe("Analyzer", () => {
     });
   });
 
+  it("should update the treemap when a chunk is deselected", async () => {
+    generateReportFrom("with-worker-loader-dynamic-import/stats.json");
+    const page = await browser.newPage();
+    await page.goto(
+      url.pathToFileURL(path.resolve(__dirname, "./output/report.html")),
+    );
+
+    const { chunkLabel, initialTreemapChunks } = await page.evaluate(() => {
+      const modulesTreemap = document
+        .querySelector("#app")
+        .__k.__k.find(
+          (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
+        ).__c;
+
+      return {
+        chunkLabel: globalThis.chartData[0].label,
+        initialTreemapChunks: modulesTreemap.treemap.props.data.map(
+          (chunk) => chunk.label,
+        ),
+      };
+    });
+
+    const checkboxChecked = await page.evaluate((label) => {
+      const checkboxLabel = [...document.querySelectorAll("label")].find(
+        (node) => node.textContent.trim().startsWith(`${label} (`),
+      );
+      const checkbox = checkboxLabel.querySelector('input[type="checkbox"]');
+      checkbox.click();
+      return checkbox.checked;
+    }, chunkLabel);
+
+    await page.evaluate(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(resolve);
+        }),
+    );
+
+    const updatedTreemapChunks = await page.evaluate(() => {
+      const modulesTreemap = document
+        .querySelector("#app")
+        .__k.__k.find(
+          (vnode) => vnode.__c && vnode.__c.handleSelectedChunksChange,
+        ).__c;
+
+      return modulesTreemap.treemap.props.data.map((chunk) => chunk.label);
+    });
+
+    expect(checkboxChecked).toBe(false);
+    expect(initialTreemapChunks).toContain(chunkLabel);
+    expect(updatedTreemapChunks).not.toContain(chunkLabel);
+  });
+
   it("should support stats files with modules inside `chunks` array", async () => {
     generateReportFrom("with-modules-in-chunks/stats.json");
     const chartData = await getChartData();


### PR DESCRIPTION
## Summary

- update `ModulesTreemap.handleSelectedChunksChange` to call `store.setSelectedChunks`
- add a browser-level regression test using a generated multi-chunk static report
- add a patch changeset

## Root cause

Commit `77599a400605587eb4c27d946a1830060cad7c96` moved direct MobX state assignments behind action methods. During that refactor, the chunk-selection handler was changed from assigning `store.selectedChunks` to calling `store.setSelectedSize(selectedChunks)` instead of `store.setSelectedChunks(selectedChunks)`.

`CheckboxList` therefore updated its local checkbox state, but the selected chunks in the store remained unchanged. The treemap continued receiving the original chunks rather than a data set filtered to the current checkbox selection.

The nearby handlers introduced in the same commit were reviewed: size selection uses `setSelectedSize`, search uses `setSearchQuery`, and entrypoint/context-menu chunk filtering uses `setSelectedChunks` correctly.

## Regression test

The new Puppeteer test generates a static report containing multiple chunks, opens it in the browser, deselects a real chunk checkbox, and verifies both that the checkbox is unchecked and that the deselected chunk is absent from the data passed to `Treemap`. This test fails with the incorrect `setSelectedSize(selectedChunks)` call and passes with `setSelectedChunks(selectedChunks)`.

## Validation

- `npm run lint`
- `npm run build`
- `npm test` — 8 suites passed, 129 tests passed, 4 skipped
- manually generated a multi-chunk static report and confirmed deselection updates the checkbox, clears the “All” checkbox, removes the chunk from treemap data, and selecting all restores the original treemap data