### PR TITLE
fix: preserve compiler paths for shared plugin instances

### DIFF
--- a/.changeset/calm-compilers-report.md
+++ b/.changeset/calm-compilers-report.md
@@ -1,0 +1,5 @@
+---
+"webpack-bundle-analyzer": patch
+---
+
+Resolve bundle assets and report files against the correct compiler output path when a plugin instance is shared by multiple compilers.

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -127,7 +127,10 @@ class BundleAnalyzerPlugin {
 
       if (this.opts.generateStatsFile) {
         actions.push(() =>
-          this.generateStatsFile(stats.toJson(this.opts.statsOptions)),
+          this.generateStatsFile(
+            stats.toJson(this.opts.statsOptions),
+            compiler,
+          ),
         );
       }
 
@@ -138,15 +141,21 @@ class BundleAnalyzerPlugin {
 
       if (this.opts.analyzerMode === "server") {
         actions.push(() =>
-          this.startAnalyzerServer(stats.toJson(analyzerStatsOptions)),
+          this.startAnalyzerServer(
+            stats.toJson(analyzerStatsOptions),
+            compiler,
+          ),
         );
       } else if (this.opts.analyzerMode === "static") {
         actions.push(() =>
-          this.generateStaticReport(stats.toJson(analyzerStatsOptions)),
+          this.generateStaticReport(
+            stats.toJson(analyzerStatsOptions),
+            compiler,
+          ),
         );
       } else if (this.opts.analyzerMode === "json") {
         actions.push(() =>
-          this.generateJSONReport(stats.toJson(analyzerStatsOptions)),
+          this.generateJSONReport(stats.toJson(analyzerStatsOptions), compiler),
         );
       }
 
@@ -175,12 +184,15 @@ class BundleAnalyzerPlugin {
 
   /**
    * @param {StatsCompilation} stats stats
+   * @param {Compiler=} compiler compiler
    * @returns {Promise<void>}
    */
-  async generateStatsFile(stats) {
+  async generateStatsFile(
+    stats,
+    compiler = /** @type {Compiler} */ (this.compiler),
+  ) {
     const statsFilepath = path.resolve(
-      /** @type {Compiler} */
-      (this.compiler).outputPath,
+      compiler.outputPath,
       this.opts.statsFilename,
     );
     await fs.promises.mkdir(path.dirname(statsFilepath), { recursive: true });
@@ -200,11 +212,18 @@ class BundleAnalyzerPlugin {
 
   /**
    * @param {StatsCompilation} stats stats
+   * @param {Compiler=} compiler compiler
    * @returns {Promise<void>}
    */
-  async startAnalyzerServer(stats) {
+  async startAnalyzerServer(
+    stats,
+    compiler = /** @type {Compiler} */ (this.compiler),
+  ) {
     if (this.server) {
-      (await this.server).updateChartData(stats);
+      (await this.server).updateChartData(
+        stats,
+        this.getBundleDirFromCompiler(compiler),
+      );
     } else {
       this.server = viewer.startServer(stats, {
         openBrowser: this.opts.openAnalyzer,
@@ -212,7 +231,7 @@ class BundleAnalyzerPlugin {
         port: this.opts.analyzerPort,
         reportTitle: this.opts.reportTitle,
         compressionAlgorithm: this.opts.compressionAlgorithm,
-        bundleDir: this.getBundleDirFromCompiler(),
+        bundleDir: this.getBundleDirFromCompiler(compiler),
         logger: this.logger,
         defaultSizes: this.opts.defaultSizes,
         excludeAssets: this.opts.excludeAssets,
@@ -223,17 +242,20 @@ class BundleAnalyzerPlugin {
 
   /**
    * @param {StatsCompilation} stats stats
+   * @param {Compiler=} compiler compiler
    * @returns {Promise<void>}
    */
-  async generateJSONReport(stats) {
+  async generateJSONReport(
+    stats,
+    compiler = /** @type {Compiler} */ (this.compiler),
+  ) {
     await viewer.generateJSONReport(stats, {
       reportFilename: path.resolve(
-        /** @type {Compiler} */
-        (this.compiler).outputPath,
+        compiler.outputPath,
         this.opts.reportFilename || "report.json",
       ),
       compressionAlgorithm: this.opts.compressionAlgorithm,
-      bundleDir: this.getBundleDirFromCompiler(),
+      bundleDir: this.getBundleDirFromCompiler(compiler),
       logger: this.logger,
       excludeAssets: this.opts.excludeAssets,
     });
@@ -241,32 +263,39 @@ class BundleAnalyzerPlugin {
 
   /**
    * @param {StatsCompilation} stats stats
+   * @param {Compiler=} compiler compiler
    * @returns {Promise<void>}
    */
-  async generateStaticReport(stats) {
+  async generateStaticReport(
+    stats,
+    compiler = /** @type {Compiler} */ (this.compiler),
+  ) {
     await viewer.generateReport(stats, {
       openBrowser: this.opts.openAnalyzer,
       reportFilename: path.resolve(
-        /** @type {Compiler} */
-        (this.compiler).outputPath,
+        compiler.outputPath,
         this.opts.reportFilename || "report.html",
       ),
       reportTitle: this.opts.reportTitle,
       compressionAlgorithm: this.opts.compressionAlgorithm,
-      bundleDir: this.getBundleDirFromCompiler(),
+      bundleDir: this.getBundleDirFromCompiler(compiler),
       logger: this.logger,
       defaultSizes: this.opts.defaultSizes,
       excludeAssets: this.opts.excludeAssets,
     });
   }
 
-  getBundleDirFromCompiler() {
+  /**
+   * @param {Compiler=} compiler compiler
+   * @returns {string | null} bundle directory
+   */
+  getBundleDirFromCompiler(compiler = /** @type {Compiler} */ (this.compiler)) {
     const outputFileSystemConstructor =
       /** @type {OutputFileSystem} */
-      (/** @type {Compiler} */ (this.compiler).outputFileSystem).constructor;
+      (compiler.outputFileSystem).constructor;
 
     if (typeof outputFileSystemConstructor === "undefined") {
-      return /** @type {Compiler} */ (this.compiler).outputPath;
+      return compiler.outputPath;
     }
     switch (outputFileSystemConstructor.name) {
       case "MemoryFileSystem":
@@ -276,7 +305,7 @@ class BundleAnalyzerPlugin {
       case "AsyncMFS":
         return null;
       default:
-        return /** @type {Compiler} */ (this.compiler).outputPath;
+        return compiler.outputPath;
     }
   }
 }

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -184,13 +184,10 @@ class BundleAnalyzerPlugin {
 
   /**
    * @param {StatsCompilation} stats stats
-   * @param {Compiler=} compiler compiler
+   * @param {Compiler} compiler compiler
    * @returns {Promise<void>}
    */
-  async generateStatsFile(
-    stats,
-    compiler = /** @type {Compiler} */ (this.compiler),
-  ) {
+  async generateStatsFile(stats, compiler) {
     const statsFilepath = path.resolve(
       compiler.outputPath,
       this.opts.statsFilename,
@@ -212,13 +209,10 @@ class BundleAnalyzerPlugin {
 
   /**
    * @param {StatsCompilation} stats stats
-   * @param {Compiler=} compiler compiler
+   * @param {Compiler} compiler compiler
    * @returns {Promise<void>}
    */
-  async startAnalyzerServer(
-    stats,
-    compiler = /** @type {Compiler} */ (this.compiler),
-  ) {
+  async startAnalyzerServer(stats, compiler) {
     if (this.server) {
       (await this.server).updateChartData(
         stats,
@@ -242,13 +236,10 @@ class BundleAnalyzerPlugin {
 
   /**
    * @param {StatsCompilation} stats stats
-   * @param {Compiler=} compiler compiler
+   * @param {Compiler} compiler compiler
    * @returns {Promise<void>}
    */
-  async generateJSONReport(
-    stats,
-    compiler = /** @type {Compiler} */ (this.compiler),
-  ) {
+  async generateJSONReport(stats, compiler) {
     await viewer.generateJSONReport(stats, {
       reportFilename: path.resolve(
         compiler.outputPath,
@@ -263,13 +254,10 @@ class BundleAnalyzerPlugin {
 
   /**
    * @param {StatsCompilation} stats stats
-   * @param {Compiler=} compiler compiler
+   * @param {Compiler} compiler compiler
    * @returns {Promise<void>}
    */
-  async generateStaticReport(
-    stats,
-    compiler = /** @type {Compiler} */ (this.compiler),
-  ) {
+  async generateStaticReport(stats, compiler) {
     await viewer.generateReport(stats, {
       openBrowser: this.opts.openAnalyzer,
       reportFilename: path.resolve(
@@ -286,10 +274,10 @@ class BundleAnalyzerPlugin {
   }
 
   /**
-   * @param {Compiler=} compiler compiler
+   * @param {Compiler} compiler compiler
    * @returns {string | null} bundle directory
    */
-  getBundleDirFromCompiler(compiler = /** @type {Compiler} */ (this.compiler)) {
+  getBundleDirFromCompiler(compiler) {
     const outputFileSystemConstructor =
       /** @type {OutputFileSystem} */
       (compiler.outputFileSystem).constructor;

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -115,7 +115,7 @@ function getChartData(analyzerOpts, bundleStats, bundleDir) {
  * @property {AnalyzerUrl} analyzerUrl analyzer url
  */
 
-/** @typedef {{ ws: WebSocketServer, http: Server, updateChartData: (bundleStats: StatsCompilation) => void }} ViewerServerObj */
+/** @typedef {{ ws: WebSocketServer, http: Server, updateChartData: (bundleStats: StatsCompilation, bundleDir?: string | null) => void }} ViewerServerObj */
 
 /**
  * @param {StatsCompilation} bundleStats bundle stats
@@ -207,9 +207,14 @@ async function startServer(bundleStats, opts) {
 
   /**
    * @param {StatsCompilation} bundleStats bundle stats
+   * @param {string | null=} updatedBundleDir bundle directory
    */
-  function updateChartData(bundleStats) {
-    const newChartData = getChartData(analyzerOpts, bundleStats, bundleDir);
+  function updateChartData(bundleStats, updatedBundleDir = bundleDir) {
+    const newChartData = getChartData(
+      analyzerOpts,
+      bundleStats,
+      updatedBundleDir,
+    );
 
     if (!newChartData) return;
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -129,6 +129,31 @@ describe("Plugin", () => {
       expect(chartData).toBeDefined();
     });
 
+    it("should use each compiler output path when a plugin instance is reused", async () => {
+      const plugin = new BundleAnalyzerPlugin({
+        analyzerMode: "json",
+        logLevel: "error",
+      });
+      const firstConfig = makeWebpackConfig();
+      const secondConfig = makeWebpackConfig();
+
+      firstConfig.output.path = path.resolve(__dirname, "./output/first");
+      firstConfig.plugins = [plugin];
+      secondConfig.output.path = path.resolve(__dirname, "./output/second");
+      secondConfig.plugins = [plugin];
+
+      await webpackCompile([firstConfig, secondConfig]);
+
+      for (const output of ["first", "second"]) {
+        const reportPath = path.resolve(
+          __dirname,
+          `./output/${output}/report.json`,
+        );
+        expect(fs.existsSync(reportPath)).toBe(true);
+        expect(JSON.parse(fs.readFileSync(reportPath, "utf8"))).not.toEqual([]);
+      }
+    });
+
     it("should support webpack config with `multi` module", async () => {
       const config = makeWebpackConfig();
 


### PR DESCRIPTION
## Summary

Fixes #506.

A `BundleAnalyzerPlugin` instance can be applied to multiple compilers, but the plugin previously stored only the most recently applied compiler. As a result, every done-hook callback resolved bundle assets and report files against that compiler's output directory.

This change:

- passes the compiler captured by each done-hook closure into report and stats generation;
- resolves bundle directories and output filenames against that compiler;
- uses the current compiler's bundle directory when refreshing server-mode chart data; and
- adds a multi-compiler regression test with one shared plugin instance for both Webpack 4 and Webpack 5.

## Testing

- `npm exec -- jest test/plugin.js --runInBand --testNamePattern=should.use.each.compiler.output.path` (2 passed)
- `npm exec -- jest test/viewer.js --runInBand` (5 passed)
- `npm exec -- eslint src/BundleAnalyzerPlugin.js src/viewer.js test/plugin.js`
- `npm exec -- tsc --pretty --noEmit`
- `npm exec -- prettier --check src/BundleAnalyzerPlugin.js src/viewer.js test/plugin.js .changeset/calm-compilers-report.md`
- `npm run build`