### PR TITLE
Add Jenkins sandboxed iframe troubleshooting entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,16 @@ No bundles were parsed. Analyzer will show only original module sizes from stats
 
 To get more information about it you can read [issue #147](https://github.com/webpack/webpack-bundle-analyzer/issues/147).
 
+### The static report is blank when viewed in Jenkins
+
+Jenkins' HTML Publisher Plugin renders reports inside a sandboxed `iframe`, which blocks the inline `<script>` tags that `webpack-bundle-analyzer` uses to render the treemap. This shows up in the browser console as errors like:
+
+```
+Blocked script execution in '<URL>' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
+```
+
+This is a Jenkins configuration issue rather than something `webpack-bundle-analyzer` can fix on its own. It can be resolved by relaxing Jenkins' Content-Security-Policy for the report directory, for example by setting the `hudson.model.DirectoryBrowserSupport.CSP` system property. See [issue #168](https://github.com/webpack/webpack-bundle-analyzer/issues/168#issuecomment-381748354) for the full details and the exact property value that fixes this.
+
 <h2 align="center">Other tools</h2>
 
 - [Statoscope](https://github.com/smelukov/statoscope/blob/master/packages/ui-webpack/README.md) - Webpack bundle analyzing tool to find out why a certain module was bundled (and more features, including interactive treemap)


### PR DESCRIPTION
Fixes #168

## What broke / what was missing

When the static report is viewed through Jenkins' HTML Publisher Plugin, the page renders blank because Jenkins serves it inside a sandboxed `iframe` that blocks the inline `<script>` tags the report relies on to render the treemap. This is a known issue, but the README's Troubleshooting section didn't mention it, so users have to dig through the issue thread to find the fix.

## What changed

Added a "The static report is blank when viewed in Jenkins" entry to the Troubleshooting section, following the same format as the existing entries. It explains why this happens and links to the issue comment that has the exact `hudson.model.DirectoryBrowserSupport.CSP` system property fix, per @valscion's request on the issue.

## How it was verified

Docs-only change (README.md). Ran `npx prettier --check README.md` against the updated file and it passes.